### PR TITLE
Add linux code_test script (code_test_linux.sh)

### DIFF
--- a/code_test_linux.sh
+++ b/code_test_linux.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+echo "====================================="
+echo "^> Code Cyclomatic Complexity (radon)"
+echo "====================================="
+radon cc src/jmc --min C -s --total-average
+echo "====================================="
+echo "^> Code Maintainability Index (radon) "
+echo "====================================="
+radon mi src/jmc --min B -s
+echo "=================================="
+echo "^> Unit/Integration Tests (python)"
+echo "=================================="
+python src/tests/test_all.py || exit 1
+echo "===================="
+echo "^> Type hints (mypy)"
+echo "===================="
+mypy ./src/jmc
+echo "================================="
+echo "^> Code Style(PEP8) (pycodestyle)"
+echo "================================="
+pycodestyle ./src --ignore=E501,W50
+# pylint src/jmc --disable=C0301,W1201,W1203

--- a/code_test_linux.sh
+++ b/code_test_linux.sh
@@ -3,7 +3,7 @@
 echo "====================================="
 echo "> Code Cyclomatic Complexity (radon)"
 echo "====================================="
-radon cc src/jmc --min C -s --total-average
+radon cc src/jmc --min C -s --total-average | grep 'Average complexity:'
 echo "====================================="
 echo "> Code Maintainability Index (radon) "
 echo "====================================="

--- a/code_test_linux.sh
+++ b/code_test_linux.sh
@@ -1,23 +1,23 @@
 #!/bin/sh
 
 echo "====================================="
-echo "^> Code Cyclomatic Complexity (radon)"
+echo "> Code Cyclomatic Complexity (radon)"
 echo "====================================="
 radon cc src/jmc --min C -s --total-average
 echo "====================================="
-echo "^> Code Maintainability Index (radon) "
+echo "> Code Maintainability Index (radon) "
 echo "====================================="
 radon mi src/jmc --min B -s
 echo "=================================="
-echo "^> Unit/Integration Tests (python)"
+echo "> Unit/Integration Tests (python)"
 echo "=================================="
 python src/tests/test_all.py || exit 1
 echo "===================="
-echo "^> Type hints (mypy)"
+echo "> Type hints (mypy)"
 echo "===================="
 mypy ./src/jmc
 echo "================================="
-echo "^> Code Style(PEP8) (pycodestyle)"
+echo "> Code Style(PEP8) (pycodestyle)"
 echo "================================="
 pycodestyle ./src --ignore=E501,W50
 # pylint src/jmc --disable=C0301,W1201,W1203


### PR DESCRIPTION
Planning to maybe contribute in the future, and I use Linux. So I thought I'd chip in with a Linux shell script for code testing!

It's basically identical to `code_test.bat`, except the following changes:
- A shell shebang at the top: `#!/bin/bash`
- Double quotation marks around `echo` strings to avoid escaping `>`
- Pipe `radon cc ...` into grep to regex match for average complexity
- `#` shell comment instead of batch `@REM`