### PR TITLE
Switch-case statements can now start at any number

### DIFF
--- a/src/jmc/compile/command/_flow_control.py
+++ b/src/jmc/compile/command/_flow_control.py
@@ -147,7 +147,7 @@ SWITCH_CASE_NAME = "switch_case"
 
 
 def __parse_switch_binary(min_: int, max_: int, count: str, datapack: DataPack,
-                          func_contents: list[list[str]], scoreboard_player: ScoreboardPlayer, name: str) -> None:
+                          func_contents: list[list[str]], scoreboard_player: ScoreboardPlayer, name: str, start_at: int = 1) -> None:
     """
     For recursion of JMC switch-case's binary tree
 
@@ -164,7 +164,7 @@ def __parse_switch_binary(min_: int, max_: int, count: str, datapack: DataPack,
         raise ValueError("min_ is more than max_ in __parse_switch_binary")
     if max_ == min_:
         datapack.add_raw_private_function(
-            name, func_contents[min_ - 1], count)
+            name, func_contents[min_ - start_at], count)
     else:
         count_less = datapack.get_count(name)
         count_more = datapack.get_count(name)
@@ -185,13 +185,13 @@ def __parse_switch_binary(min_: int, max_: int, count: str, datapack: DataPack,
             ], count)
 
         __parse_switch_binary(min_, half1, count_less,
-                              datapack, func_contents, scoreboard_player, name)
+                              datapack, func_contents, scoreboard_player, name, start_at)
         __parse_switch_binary(half2, max_, count_more,
-                              datapack, func_contents, scoreboard_player, name)
+                              datapack, func_contents, scoreboard_player, name, start_at)
 
 
 def parse_switch(scoreboard_player: ScoreboardPlayer,
-                 func_contents: list[list[str]], start: int, datapack: DataPack, name: str = SWITCH_CASE_NAME) -> str:
+                 func_contents: list[list[str]], start_at: int, datapack: DataPack, name: str = SWITCH_CASE_NAME) -> str:
     """
     Create a binary tree for JMC switch-case
 
@@ -202,8 +202,8 @@ def parse_switch(scoreboard_player: ScoreboardPlayer,
     :return: Minecraft function call to initiate switch case
     """
     count = datapack.get_count(name)
-    __parse_switch_binary(start, len(func_contents) + start - 1, count,
-                          datapack, func_contents, scoreboard_player, name)
+    __parse_switch_binary(start_at, len(func_contents) + start_at - 1, count,
+                          datapack, func_contents, scoreboard_player, name, start_at)
     return f"function {datapack.namespace}:{DataPack.private_name}/{name}/{count}"
 
 
@@ -246,8 +246,12 @@ def switch(command: list[Token], datapack: DataPack,
             if len(tokens) == 1:
                 raise JMCSyntaxException(
                     "Expected case number", tokens[0], tokenizer, col_length=True)
-            count_str = tokens[1].string
-            if not count_str.isalnum():
+            if tokens[1].string == "-":
+                count_str = tokens[1].string + tokens[2].string
+                tokens.pop(2)
+            else:
+                count_str = tokens[1].string
+            if not count_str.lstrip('-').isalnum():
                 raise JMCSyntaxException(
                     "Expected case number", tokens[1], tokenizer)
 

--- a/src/jmc/compile/command/builtin_function/execute_excluded.py
+++ b/src/jmc/compile/command/builtin_function/execute_excluded.py
@@ -250,7 +250,7 @@ class HardcodeSwitch(JMCFunction):
                 error.msg = f"WARNING: This error happens inside {self.call_string}, error position might not be accurate\n\n" + error.msg
                 raise error
 
-        return parse_switch(scoreboard_player, func_contents,
+        return parse_switch(scoreboard_player, func_contents, 1,
                             self.datapack, self.name)
 
 

--- a/src/jmc/compile/command/builtin_function/execute_excluded.py
+++ b/src/jmc/compile/command/builtin_function/execute_excluded.py
@@ -212,7 +212,8 @@ class HardcodeRepeatLists(JMCFunction):
         "switch": ArgType.SCOREBOARD,
         "indexString": ArgType.STRING,
         "function": ArgType.ARROW_FUNC,
-        "count": ArgType.INTEGER
+        "count": ArgType.INTEGER,
+        "begin_at": ArgType.INTEGER,
     },
     name="hardcode_switch",
     ignore={
@@ -221,15 +222,19 @@ class HardcodeRepeatLists(JMCFunction):
     },
     number_type={
         "count": NumberType.POSITIVE
+    },
+    defaults={
+        "begin_at": "1"
     }
 )
 class HardcodeSwitch(JMCFunction):
     def call(self) -> str:
+        begin_at = int(self.args["begin_at"])
         count = int(self.args["count"])
         func_contents: list[list[str]] = []
         scoreboard_player = find_scoreboard_player_type(
             self.raw_args["switch"].token, self.tokenizer)
-        for i in range(1, count + 1):
+        for i in range(begin_at, count + 1):
             try:
                 func_contents.append(self.datapack.parse_function_token(
                     Token(
@@ -250,7 +255,7 @@ class HardcodeSwitch(JMCFunction):
                 error.msg = f"WARNING: This error happens inside {self.call_string}, error position might not be accurate\n\n" + error.msg
                 raise error
 
-        return parse_switch(scoreboard_player, func_contents, 1,
+        return parse_switch(scoreboard_player, func_contents, begin_at,
                             self.datapack, self.name)
 
 

--- a/src/jmc/compile/command/builtin_function/load_only.py
+++ b/src/jmc/compile/command/builtin_function/load_only.py
@@ -419,7 +419,7 @@ class TriggerSetup(JMCFunction):
                         [f"function {self.datapack.namespace}:{func}"])
             run = [
                 parse_switch(ScoreboardPlayer(
-                    PlayerType.SCOREBOARD, (obj, "@s")), func_contents, self.datapack, self.name),
+                    PlayerType.SCOREBOARD, (obj, "@s")), func_contents, 1, self.datapack, self.name),
             ]
         else:
             run = []

--- a/src/jmc/compile/command/var_operation.py
+++ b/src/jmc/compile/command/var_operation.py
@@ -125,7 +125,7 @@ def variable_operation(
 
         if len(tokens) > 3:
             if (  # If rvar is obj:selector
-                len(tokens) == 5
+                len(tokens) >= 5
                 and
                 tokens[3].token_type == TokenType.OPERATOR
                 and
@@ -133,7 +133,12 @@ def variable_operation(
                 and
                 tokens[4].token_type == TokenType.KEYWORD
             ):
-                right_token = tokenizer.merge_tokens(tokens[2:5])
+                if len(tokens) == 5:
+                    right_token = tokenizer.merge_tokens(tokens[2:5])
+                elif len(tokens) == 6:
+                    tokens[5] = Token(tokens[5].token_type, tokens[5].line, tokens[5].col, datapack.lexer.clean_up_paren_token(
+                        tokens[5], tokenizer))
+                    right_token = tokenizer.merge_tokens(tokens[2:6])
             else:
                 raise JMCSyntaxException(
                     f"Unexpected token ('{tokens[3].string}') after variable/integer ('{tokens[2].string}')", tokens[3], tokenizer, suggestion="Probably missing semicolon.")


### PR DESCRIPTION
Simple change that doesn't affect the optimization. Useful because often ones needs it to start at a value of 0 or -1 instead of at 1.

NOTE: this still keeps the "numbers have to be in sequence without skipping" restriction.