### PR TITLE
Add support for multiple namespaces

### DIFF
--- a/src/jmc/compile/compiling.py
+++ b/src/jmc/compile/compiling.py
@@ -323,13 +323,9 @@ def build(datapack: DataPack, config: "Configuration", is_delete: bool, cert_con
 
     for func_path, func in datapack.functions.items():
         namespace = func_path.split("/")[0]
-        if header.is_override_minecraft and func_path.startswith("minecraft/"):
-            # len("minecraft/") = 10
-            path = output_folder / "data" / "minecraft" / "functions" / \
-                (func_path[10:] + ".mcfunction")
-        elif namespace in header.custom_namespaces:
+        if namespace in header.namespace_overrides:
              path = output_folder / "data" / namespace / "functions" / \
-                (func_path[func_path.index("/"):] + ".mcfunction")
+                (func_path[len(namespace)+1:] + ".mcfunction")
         else:
             path = namespace_folder / "functions" / (func_path + ".mcfunction")
         content = post_process(func.content)
@@ -343,13 +339,9 @@ def build(datapack: DataPack, config: "Configuration", is_delete: bool, cert_con
 
     for json_path, json in datapack.jsons.items():
         namespace = json_path.split("/")[0]
-        if header.is_override_minecraft and json_path.startswith("minecraft/"):
-            # len("minecraft/") = 10
+        if namespace in header.namespace_overrides:
             path = output_folder / "data" / \
-                "minecraft" / (json_path[10:] + ".json")
-        elif namespace in header.custom_namespaces:
-            path = output_folder / "data" / \
-                namespace / (json_path[json_path.index("/"):] + ".json")
+                namespace / (json_path[len(namespace)+1:] + ".json")
         else:
             path = namespace_folder / (json_path + ".json")
         if json:

--- a/src/jmc/compile/compiling.py
+++ b/src/jmc/compile/compiling.py
@@ -329,7 +329,7 @@ def build(datapack: DataPack, config: "Configuration", is_delete: bool, cert_con
                 (func_path[10:] + ".mcfunction")
         elif namespace in header.custom_namespaces:
              path = output_folder / "data" / namespace / "functions" / \
-                (func_path[index("/"):] + ".mcfunction")
+                (func_path[func_path.index("/"):] + ".mcfunction")
         else:
             path = namespace_folder / "functions" / (func_path + ".mcfunction")
         content = post_process(func.content)
@@ -349,7 +349,7 @@ def build(datapack: DataPack, config: "Configuration", is_delete: bool, cert_con
                 "minecraft" / (json_path[10:] + ".json")
         elif namespace in header.custom_namespaces:
             path = output_folder / "data" / \
-                namespace / (json_path[index("/"):] + ".json")
+                namespace / (json_path[json_path.index("/"):] + ".json")
         else:
             path = namespace_folder / (json_path + ".json")
         if json:

--- a/src/jmc/compile/compiling.py
+++ b/src/jmc/compile/compiling.py
@@ -322,10 +322,14 @@ def build(datapack: DataPack, config: "Configuration", is_delete: bool, cert_con
                 dump(tick_json, file, indent=4)
 
     for func_path, func in datapack.functions.items():
+        namespace = func_path.split("/")[0]
         if header.is_override_minecraft and func_path.startswith("minecraft/"):
             # len("minecraft/") = 10
             path = output_folder / "data" / "minecraft" / "functions" / \
                 (func_path[10:] + ".mcfunction")
+        elif namespace in header.custom_namespaces:
+             path = output_folder / "data" / namespace / "functions" / \
+                (func_path[index("/"):] + ".mcfunction")
         else:
             path = namespace_folder / "functions" / (func_path + ".mcfunction")
         content = post_process(func.content)
@@ -338,10 +342,14 @@ def build(datapack: DataPack, config: "Configuration", is_delete: bool, cert_con
                     file.write(content)
 
     for json_path, json in datapack.jsons.items():
+        namespace = json_path.split("/")[0]
         if header.is_override_minecraft and json_path.startswith("minecraft/"):
             # len("minecraft/") = 10
             path = output_folder / "data" / \
                 "minecraft" / (json_path[10:] + ".json")
+        elif namespace in header.custom_namespaces:
+            path = output_folder / "data" / \
+                namespace / (json_path[index("/"):] + ".json")
         else:
             path = namespace_folder / (json_path + ".json")
         if json:

--- a/src/jmc/compile/header.py
+++ b/src/jmc/compile/header.py
@@ -77,6 +77,7 @@ class Header(SingleTon):
         obj.credits = []
         obj.is_enable_macro = True
         obj.is_override_minecraft = False
+        obj.custom_namespaces = set()
         obj.commands = set()
         obj.statics = set()
         obj.dels = set()

--- a/src/jmc/compile/header.py
+++ b/src/jmc/compile/header.py
@@ -48,7 +48,7 @@ class Header(SingleTon):
     """Dictionary of string to replace and what to replace it with"""
     is_enable_macro: bool
     """Whether to enable macro at the time of creating a token"""
-    is_override_minecraft: bool
+    namespace_overrides: set[str]
     """Whether to allow jmc to take control over minecraft namespace"""
     commands: set[str]
     """List of extra command(first arguments) to allow"""
@@ -76,8 +76,7 @@ class Header(SingleTon):
         obj.macros = {}
         obj.credits = []
         obj.is_enable_macro = True
-        obj.is_override_minecraft = False
-        obj.custom_namespaces = set()
+        obj.namespace_overrides = set()
         obj.commands = set()
         obj.statics = set()
         obj.dels = set()

--- a/src/jmc/compile/header_parse.py
+++ b/src/jmc/compile/header_parse.py
@@ -263,6 +263,12 @@ def __parse_header(header_str: str, file_name: str,
                     f"Expected 0 arguments after '#override_minecraft' (got {len(arg_tokens)})", file_name, line, line_str)
             header.is_override_minecraft = True
 
+        elif directive_token.string == "namespace":
+            if not arg_tokens or len(arg_tokens) != 1:
+                raise HeaderSyntaxException(
+                    f"Expected 1 arguments after '#namespace' (got {len(arg_tokens)})", file_name, line, line_str)
+            header.custom_namespaces.add(arg_tokens[0])
+
         # #command
         elif directive_token.string == "command":
             if not arg_tokens or len(arg_tokens) != 1:

--- a/src/jmc/compile/header_parse.py
+++ b/src/jmc/compile/header_parse.py
@@ -256,18 +256,13 @@ def __parse_header(header_str: str, file_name: str,
             else:
                 header.credits.append("")
 
-        # #override_minecraft
-        elif directive_token.string == "override_minecraft":
-            if arg_tokens:
-                raise HeaderSyntaxException(
-                    f"Expected 0 arguments after '#override_minecraft' (got {len(arg_tokens)})", file_name, line, line_str)
-            header.is_override_minecraft = True
+        # #override
 
-        elif directive_token.string == "namespace":
+        elif directive_token.string == "override":
             if not arg_tokens or len(arg_tokens) != 1:
                 raise HeaderSyntaxException(
                     f"Expected 1 arguments after '#namespace' (got {len(arg_tokens)})", file_name, line, line_str)
-            header.custom_namespaces.add(arg_tokens[0])
+            header.namespace_overrides.add(arg_tokens[0].string)
 
         # #command
         elif directive_token.string == "command":

--- a/src/jmc/compile/lexer.py
+++ b/src/jmc/compile/lexer.py
@@ -358,9 +358,9 @@ class Lexer:
         json_name = prefix + convention_jmc_to_mc(
             command[2], tokenizer, is_make_lower=False, substr=(1, -1))
 
-        if Header().is_override_minecraft and json_name.startswith("minecraft/"):
-            # len('minecraft/') = 10
-            json_path = "minecraft/" + json_type + "/" + json_name[10:]
+        namespace = json_name.split("/")[0]
+        if namespace in Header().namespace_overrides:
+            json_path = namespace + "/" + json_type + "/" + json_name[len(namespace)+1:]
         else:
             json_path = json_type + "/" + json_name
 


### PR DESCRIPTION
Use `#namespace` preprocessor directive in header. Example below:


```h
#namespace mynamespace
``` 
```ts
class mynamespace {
    function test() {
        say "This'll be at mynamespace:test";
    }
}
class anotherclass {
    function test() {
        say "This'll be at currentnamespace:anotherclass/test";
    }
}
```