### PR TITLE
Allow multiline strings in JSON

### DIFF
--- a/src/jmc/compile/command/jmc_function.py
+++ b/src/jmc/compile/command/jmc_function.py
@@ -280,7 +280,7 @@ class JMCFunction:
         :return: JSON
         """
         try:
-            json = loads(self.args[parameter])
+            json = loads(self.args[parameter].replace('\t', '').replace('\n', ''))
         except JSONDecodeError as error:
             raise JMCDecodeJSONError(
                 error, self.raw_args[parameter].token, self.tokenizer) from error

--- a/src/jmc/compile/lexer.py
+++ b/src/jmc/compile/lexer.py
@@ -402,7 +402,7 @@ class Lexer:
                 suggestion=f"This json was already defined at line {old_json_token.line} col {old_json_token.col} in {old_json_tokenizer.file_path}")
 
         try:
-            json: dict[str, str] = loads(json_content)
+            json: dict[str, str] = loads(json_content.replace('\t', '').replace('\n', ''))
         except JSONDecodeError as error:
             raise JMCDecodeJSONError(error, command[3], tokenizer) from error
         if not json:


### PR DESCRIPTION
The code will simply remove newlines and tabs before parsing, which seems to work fine.