### PR TITLE
Fix quoted booleans in tellraw JSON

### DIFF
--- a/src/jmc/compile/command/utils.py
+++ b/src/jmc/compile/command/utils.py
@@ -615,7 +615,6 @@ class FormattedText:
                 if isinstance(json_body, dict) and 'nbt' in json_body.keys():
                     self.current_json[key] = {}
                     self.current_json[key]["nbt"] = json_body["nbt"](arg)  # type: ignore # fmt: off
-                    self.current_json[key]["interpret"] = json_body["interpret"](arg)  # type: ignore # fmt: off
                     if "separator" in json_body.keys():
                         self.current_json[key]["separator"] = json_body["separator"](arg)  # type: ignore # fmt: off
 
@@ -663,7 +662,8 @@ class FormattedText:
 
             if "__private_nbt_expand__" in self.current_json:
                 self.current_json["nbt"] = self.current_json["__private_nbt_expand__"]["nbt"]  # type: ignore # fmt: off
-                self.current_json["interpret"] = self.current_json["__private_nbt_expand__"]["interpret"]  # type: ignore # fmt: off
+                self.current_json["interpret"] =
+                    (self.current_json["__private_nbt_expand__"]["interpret"] == "true") # type: ignore # fmt: off
                 if "separator" in self.current_json["__private_nbt_expand__"].keys():  # type: ignore # fmt: off
                     self.current_json["separator"] = self.current_json["__private_nbt_expand__"]["separator"]  # type: ignore # fmt: off
                 if "storage" in self.current_json["__private_nbt_expand__"]:  # type: ignore # fmt: off


### PR DESCRIPTION
As of the new Minecraft snapshot 23w40a, quoted booleans (eg. `"interpret": "true"`) are no longer valid syntax in a tellraw command. However, unquoted booleans (`"interpret": true`) were already valid and will continue to be valid, so this commit ensures forward compatibility while still retaining backward compatibility.