### PR TITLE
Prevent UB caused by changing switch/case variables

### DIFF
--- a/src/jmc/compile/command/condition.py
+++ b/src/jmc/compile/command/condition.py
@@ -196,7 +196,8 @@ def custom_condition(
 
     conditions: list[str] = []
     if tokens[0].string not in {"biome", "block", "blocks",
-                                "data", "dimension", "entity", "loaded", "predicate", "score"}:
+                                "data", "dimension", "entity", 
+                                "loaded", "predicate", "score"}:
         raise JMCValueError(
             f"Unrecognized condition '{tokens[0].string}'",
             tokens[0],

--- a/src/jmc/compile/datapack_data.py
+++ b/src/jmc/compile/datapack_data.py
@@ -126,6 +126,7 @@ class Data:
         "item",
         "__item_id_count",
         "condition_count",
+        "switch_count",
         "__bool_result_count",
         "scoreboards",
         "teams",
@@ -137,6 +138,7 @@ class Data:
         self.item: dict[str, Item] = {}
         self.__item_id_count = 0
         self.condition_count = 0  # Used in condition.py
+        self.switch_count = -1 # Used in _flow_control.py
         self.__bool_result_count = -1  # Used in BOOL_FUNCTION
         self.scoreboards: dict[str, tuple[str, str, "Token"]] = {}
         self.teams: dict[str, tuple[str, "Token"]] = {}
@@ -170,3 +172,17 @@ class Data:
         """
         self.__bool_result_count += 1
         return f"__bool_result__{self.__bool_result_count}"
+    
+    def get_current_switch(self) -> str:
+        """
+        Get switch string (variable) for pre-1.20.2 switch/case (starts at 0)
+
+        :return: __switch_n
+        .. example::
+        >>> data.get_current_switch()
+        "__switch__0"
+        >>> data.get_current_switch()
+        "__switch__1"
+        """
+        self.switch_count += 1
+        return f"__switch__{self.switch_count}"


### PR DESCRIPTION
Only applies to pre-macro `switch` (pack_format ≤ 15)