### PR TITLE
Fix bug with `extend`ing a JSON file from another class

### DIFF
--- a/src/jmc/compile/lexer.py
+++ b/src/jmc/compile/lexer.py
@@ -475,7 +475,7 @@ class Lexer:
                 "JSON content cannot be empty", command[-1], tokenizer)
 
         if has_extends_arg:
-            super_name = prefix + convention_jmc_to_mc(
+            super_name = convention_jmc_to_mc(
                 command[4], tokenizer, is_make_lower=False, substr=(1, -1))
             if namespace in Header().namespace_overrides:
                 super_path = namespace + "/" + json_type + \


### PR DESCRIPTION
`prefix +` makes it look for the file in the current class, which made it impossible to extend JSON files from other classes or the global scope. To look inside the current class, use dot notation instead.