### PR TITLE
Object.isEqual() & String.isEqual() dont require `type` argument now

### DIFF
--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -27,17 +27,17 @@ class TimerIsOver(JMCFunction):
         ]
 
 class NbtSource: 
-    def __init__(self, nbt_source: str):
-        self.nbt_source = nbt_source
+    def __init__(self, source: str):
+        self.source = source
 
-    def is_uuid(nbt_source: str) -> bool:
-        parts = nbt_source.split('-')
+    def is_uuid(source: str) -> bool:
+        parts = source.split('-')
         return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
     
-    def get_type(nbt_source: str) -> str:
-        if nbt_source.startswith("@") or NbtSource.is_uuid(nbt_source):
+    def get_type(self) -> str:
+        if self.source.startswith("@") or NbtSource.is_uuid(self.source):
             return "entity"
-        elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', nbt_source): # checks if the string is block coord with regex
+        elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', self.source): # checks if the string is block coord with regex
             return "block"
         return "storage"
     

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -29,7 +29,7 @@ class TimerIsOver(JMCFunction):
 class NbtSource: 
     def __init__(self: str, source: str):
         self.source = source
-        return self
+        return None
 
     def is_uuid(source: str) -> bool:
         parts = source.split('-')

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -27,17 +27,17 @@ class TimerIsOver(JMCFunction):
         ]
 
 class NbtSource: 
-    def __init__(self, source: str):
-        self.source = source
+    def __init__(self, nbt_source: str):
+        self.nbt_source = nbt_source
 
-    def is_uuid(source: str) -> bool:
-        parts = source.split('-')
+    def is_uuid(nbt_source: str) -> bool:
+        parts = nbt_source.split('-')
         return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
     
-    def get_type(source: str) -> str:
-        if source.startswith("@") or NbtSource.is_uuid(source):
+    def get_type(nbt_source: str) -> str:
+        if nbt_source.startswith("@") or NbtSource.is_uuid(nbt_source):
             return "entity"
-        elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', source): # checks if the string is block coord with regex
+        elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', nbt_source): # checks if the string is block coord with regex
             return "block"
         return "storage"
     

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -87,8 +87,8 @@ class ObjectIsEqual(JMCFunction):
         bool_result = self.datapack.data.get_current_bool_result()
         source1 = NbtSource(self.args["source1"])
         source2 = NbtSource(self.args["source2"])
-        type1 = source1.get_type(source1)
-        type2 = source2.get_type(source2)
+        type1 = source1.get_type()
+        type2 = source2.get_type()
         if type1 == "storage" and ":" not in self.args["source1"]:
             source1 = f"{self.datapack.namespace}:{source1}"
         if type2 == "storage" and ":" not in self.args["source2"]:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -26,16 +26,16 @@ class TimerIsOver(JMCFunction):
         return f'score {self.args["selector"]} {self.args["objective"]} matches 1..', UNLESS, [
         ]
 
-class nbtSource: 
-    def __init__(self, source):
+class NbtSource: 
+    def __init__(self, source: str):
         self.source = source
 
     def is_uuid(source: str) -> bool:
         parts = source.split('-')
         return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
     
-    def get_source_type(source: str) -> str:
-        if source.startswith("@") or nbtSource.is_uuid(source):
+    def get_type(source: str) -> str:
+        if source.startswith("@") or NbtSource.is_uuid(source):
             return "entity"
         elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', source): # checks if the string is block coord with regex
             return "block"
@@ -57,8 +57,9 @@ class StringIsEqual(JMCFunction):
 
     def call_bool(self) -> tuple[str, bool, list[str]]:
         bool_result = self.datapack.data.get_current_bool_result()
-        source = self.args["source"]
-        source_type = nbtSource.get_source_type(source)
+        # source = self.args["source"]
+        source = NbtSource(self.args["source"])
+        source_type = source.get_type()
         if source_type == "storage" and ":" not in self.args["source"]:
             source = f"{self.datapack.namespace}:{source}"
 
@@ -84,10 +85,10 @@ class ObjectIsEqual(JMCFunction):
 
     def call_bool(self) -> tuple[str, bool, list[str]]:
         bool_result = self.datapack.data.get_current_bool_result()
-        source1 = self.args["source1"]
-        source2 = self.args["source2"]
-        type1 = nbtSource.get_source_type(source1)
-        type2 = nbtSource.get_source_type(source2)
+        source1 = NbtSource(self.args["source1"])
+        source2 = NbtSource(self.args["source2"])
+        type1 = source1.get_type(source1)
+        type2 = source2.get_type(source2)
         if type1 == "storage" and ":" not in self.args["source1"]:
             source1 = f"{self.datapack.namespace}:{source1}"
         if type2 == "storage" and ":" not in self.args["source2"]:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -27,8 +27,9 @@ class TimerIsOver(JMCFunction):
         ]
 
 class NbtSource: 
-    def __init__(self, source: str):
+    def __init__(self: str, source: str):
         self.source = source
+        return self
 
     def is_uuid(source: str) -> bool:
         parts = source.split('-')
@@ -57,7 +58,6 @@ class StringIsEqual(JMCFunction):
 
     def call_bool(self) -> tuple[str, bool, list[str]]:
         bool_result = self.datapack.data.get_current_bool_result()
-        # source = self.args["source"]
         source = NbtSource(self.args["source"])
         source_type = source.get_type()
         if source_type == "storage" and ":" not in self.args["source"]:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -3,6 +3,7 @@
 from ..utils import ArgType
 from ..jmc_function import JMCFunction, FuncType, func_property
 from ...exception import JMCValueError
+import re
 
 IF = True
 UNLESS = False
@@ -33,7 +34,7 @@ class nbtSource:
     def get_source_type(source) -> str:
         if source.startswith("@") or nbtSource.is_uuid(source):
             source_type = "entity"
-        elif source[0] in "~^" or source.isnumeric():
+        elif source[0] in "~^" or re.match(r"^\d+$", source):
             source_type = "block"
         else:
             source_type = "storage"

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -28,10 +28,10 @@ class TimerIsOver(JMCFunction):
 
 # please put this somewhere in appropriate place, idk where to put these 2 functions so for now they're here.
 class nbtSource: 
-    def is_uuid(string) -> bool:
+    def is_uuid(string: str) -> bool:
         parts = string.split('-')
         return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
-    def get_source_type(source) -> str:
+    def get_source_type(source: str) -> str:
         if source.startswith("@") or nbtSource.is_uuid(source):
             source_type = "entity"
         elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', source):

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -56,12 +56,12 @@ class StringIsEqual(JMCFunction):
     def call_bool(self) -> tuple[str, bool, list[str]]:
         bool_result = self.datapack.data.get_current_bool_result()
         source = self.args["source"]
-        type = nbtSource.get_source_type(source)
-        if type == "storage" and ":" not in self.args["source"]:
+        source_type = nbtSource.get_source_type(source)
+        if source_type == "storage" and ":" not in self.args["source"]:
             source = f"{self.datapack.namespace}:{source}"
 
         return f"score {bool_result} {self.datapack.var_name} matches 0", IF, [
-            f"data modify storage {self.datapack.namespace}:{self.datapack.storage_name} currentObject set from {type} {source} {self.args['path']}",
+            f"data modify storage {self.datapack.namespace}:{self.datapack.storage_name} currentObject set from {source_type} {source} {self.args['path']}",
             f"execute store success score {bool_result} {self.datapack.var_name} run data modify storage {self.datapack.namespace}:{self.datapack.storage_name} {self.current_object} set value {self.args['string']}"
         ]
 

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -26,19 +26,21 @@ class TimerIsOver(JMCFunction):
         return f'score {self.args["selector"]} {self.args["objective"]} matches 1..', UNLESS, [
         ]
 
-# please put this somewhere in appropriate place, idk where to put these 2 functions so for now they're here.
 class nbtSource: 
-    def is_uuid(string: str) -> bool:
-        parts = string.split('-')
+    def __init__(self, source):
+        self.source = source
+
+    def is_uuid(source: str) -> bool:
+        parts = source.split('-')
         return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
+    
     def get_source_type(source: str) -> str:
         if source.startswith("@") or nbtSource.is_uuid(source):
-            source_type = "entity"
+            return "entity"
         elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', source): # checks if the string is block coord with regex
-            source_type = "block"
-        else:
-            source_type = "storage"
-        return source_type
+            return "block"
+        return "storage"
+    
 
 @func_property(
     func_type=FuncType.BOOL_FUNCTION,

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -34,7 +34,7 @@ class nbtSource:
     def get_source_type(source: str) -> str:
         if source.startswith("@") or nbtSource.is_uuid(source):
             source_type = "entity"
-        elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', source):
+        elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', source): # checks if the string is block coord with regex
             source_type = "block"
         else:
             source_type = "storage"

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -8,6 +8,7 @@ import re
 IF = True
 UNLESS = False
 
+
 def is_uuid(source: str) -> bool:
     """
     Tells whether source of the data is minecraft UUID or not
@@ -31,6 +32,7 @@ def get_nbt_type(source: str) -> str:
         return "block"
     return "storage"
 
+
 @func_property(
     func_type=FuncType.BOOL_FUNCTION,
     call_string="Timer.isOver",
@@ -47,6 +49,7 @@ class TimerIsOver(JMCFunction):
     def call_bool(self) -> tuple[str, bool, list[str]]:
         return f'score {self.args["selector"]} {self.args["objective"]} matches 1..', UNLESS, [
         ]
+
 
 @func_property(
     func_type=FuncType.BOOL_FUNCTION,

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -29,7 +29,7 @@ class TimerIsOver(JMCFunction):
 class NbtSource: 
     def __init__(self: str, source: str):
         self.source = source
-        return self.source
+        # return self.source
 
     def is_uuid(source: str) -> bool:
         parts = source.split('-')
@@ -41,6 +41,9 @@ class NbtSource:
         elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', self.source): # checks if the string is block coord with regex
             return "block"
         return "storage"
+    
+    def __str__(self):
+        return f"NbtSource({self.source})"
     
 
 @func_property(

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -34,7 +34,7 @@ class nbtSource:
     def get_source_type(source) -> str:
         if source.startswith("@") or nbtSource.is_uuid(source):
             source_type = "entity"
-        elif re.match(r'/^~?\^?-?\d+\s~?\^?-?\d+\s~?\^?-?\d+/mg', source):
+        elif re.match(r'^~?\^?-?\d+\s~?\^?-?\d+\s~?\^?-?\d+', source):
             source_type = "block"
         else:
             source_type = "storage"

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -44,7 +44,6 @@ class nbtSource:
     func_type=FuncType.BOOL_FUNCTION,
     call_string="String.isEqual",
     arg_type={
-        "type": ArgType.KEYWORD,
         "source": ArgType.STRING,
         "path": ArgType.KEYWORD,
         "string": ArgType.STRING

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -27,15 +27,35 @@ class TimerIsOver(JMCFunction):
         ]
 
 class NbtSource: 
+    """
+    A class that represents a data source and provides methods to get the type of data.
+    """
     def __init__(self: str, source: str):
+        """Initializes a new instance of the NbtSource class.
+
+        Args:
+            source (str): The source of the data.
+        """
         self.source = source
-        # return self.source
 
     def is_uuid(source: str) -> bool:
+        """Checks if the given string is a UUID.
+
+        Args:
+            source (str): The string to check.
+
+        Returns:
+            bool: True if the string is a UUID; otherwise, False.
+        """
         parts = source.split('-')
         return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
     
     def get_type(self) -> str:
+        """Gets the type of data based on the data source.
+
+        Returns:
+            str: The type of data.
+        """
         if self.source.startswith("@") or NbtSource.is_uuid(self.source):
             return "entity"
         elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', self.source): # checks if the string is block coord with regex
@@ -43,6 +63,7 @@ class NbtSource:
         return "storage"
     
     def __str__(self):
+        """Returns a string representation of the NbtSource object."""
         return f"{self.source}"
 
 

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -31,7 +31,7 @@ class nbtSource:
         parts = string.split('-')
         return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
     def get_source_type(source) -> str:
-        if source.startswith("@") or ObjectIsEqual.is_uuid(source):
+        if source.startswith("@") or nbtSource.is_uuid(source):
             source_type = "entity"
         elif source[0] in "~^" or source.isnumeric():
             source_type = "block"
@@ -86,6 +86,7 @@ class ObjectIsEqual(JMCFunction):
         source2 = self.args["source2"]
         type1 = nbtSource.get_source_type(source1)
         type2 = nbtSource.get_source_type(source1)
+        print(type1, type2)
         if type1 == "storage" and ":" not in self.args["source1"]:
             source1 = f"{self.datapack.namespace}:{source1}"
         if type2 == "storage" and ":" not in self.args["source2"]:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -87,7 +87,6 @@ class ObjectIsEqual(JMCFunction):
         source2 = self.args["source2"]
         type1 = nbtSource.get_source_type(source1)
         type2 = nbtSource.get_source_type(source1)
-        print(type1, type2)
         if type1 == "storage" and ":" not in self.args["source1"]:
             source1 = f"{self.datapack.namespace}:{source1}"
         if type2 == "storage" and ":" not in self.args["source2"]:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -85,7 +85,7 @@ class ObjectIsEqual(JMCFunction):
         source1 = self.args["source1"]
         source2 = self.args["source2"]
         type1 = nbtSource.get_source_type(source1)
-        type2 = nbtSource.get_source_type(source1)
+        type2 = nbtSource.get_source_type(source2)
         if type1 == "storage" and ":" not in self.args["source1"]:
             source1 = f"{self.datapack.namespace}:{source1}"
         if type2 == "storage" and ":" not in self.args["source2"]:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -34,7 +34,7 @@ class nbtSource:
     def get_source_type(source) -> str:
         if source.startswith("@") or nbtSource.is_uuid(source):
             source_type = "entity"
-        elif source[0] in "~^" or re.match(r"^\d+$", source):
+        elif re.match(r'/^~?\^?-?\d+\s~?\^?-?\d+\s~?\^?-?\d+/mg', source):
             source_type = "block"
         else:
             source_type = "storage"

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -34,7 +34,7 @@ class nbtSource:
     def get_source_type(source) -> str:
         if source.startswith("@") or nbtSource.is_uuid(source):
             source_type = "entity"
-        elif re.match(r'^[~\^]?-?\d+(\.\d+)?\s[~\^]?-?\d+(\.\d+)?\s[~\^]?-?\d+(\.\d+)?$', source):
+        elif re.match(r'^[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?\s[~\^]?-?\d*(\.\d+)?[~\^]?$', source):
             source_type = "block"
         else:
             source_type = "storage"

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -43,7 +43,7 @@ class NbtSource:
         return "storage"
     
     def __str__(self):
-        return f"NbtSource({self.source})"
+        return f"{self.source}"
     
 
 @func_property(

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -28,7 +28,7 @@ class TimerIsOver(JMCFunction):
 
 # please put this somewhere in appropriate place, idk where to put these 2 functions so for now they're here.
 class nbtSource: 
-    def is_uuid(string) -> str:
+    def is_uuid(string) -> bool:
         parts = string.split('-')
         return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
     def get_source_type(source) -> str:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -29,7 +29,7 @@ class TimerIsOver(JMCFunction):
 class NbtSource: 
     def __init__(self: str, source: str):
         self.source = source
-        return None
+        return self.source
 
     def is_uuid(source: str) -> bool:
         parts = source.split('-')

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -87,6 +87,7 @@ class ObjectIsEqual(JMCFunction):
         source2 = self.args["source2"]
         type1 = nbtSource.get_source_type(source1)
         type2 = nbtSource.get_source_type(source1)
+        print(type1, type2)
         if type1 == "storage" and ":" not in self.args["source1"]:
             source1 = f"{self.datapack.namespace}:{source1}"
         if type2 == "storage" and ":" not in self.args["source2"]:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -34,7 +34,7 @@ class nbtSource:
     def get_source_type(source) -> str:
         if source.startswith("@") or nbtSource.is_uuid(source):
             source_type = "entity"
-        elif re.match(r'^~?\^?-?\d+\s~?\^?-?\d+\s~?\^?-?\d+', source):
+        elif re.match(r'^[~\^]?-?\d+(\.\d+)?\s[~\^]?-?\d+(\.\d+)?\s[~\^]?-?\d+(\.\d+)?$', source):
             source_type = "block"
         else:
             source_type = "storage"

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -44,7 +44,7 @@ class NbtSource:
     
     def __str__(self):
         return f"{self.source}"
-    
+
 
 @func_property(
     func_type=FuncType.BOOL_FUNCTION,

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -86,7 +86,6 @@ class ObjectIsEqual(JMCFunction):
         source2 = self.args["source2"]
         type1 = nbtSource.get_source_type(source1)
         type2 = nbtSource.get_source_type(source1)
-        print(type1, type2)
         if type1 == "storage" and ":" not in self.args["source1"]:
             source1 = f"{self.datapack.namespace}:{source1}"
         if type2 == "storage" and ":" not in self.args["source2"]:

--- a/src/jmc/compile/command/builtin_function/bool_function.py
+++ b/src/jmc/compile/command/builtin_function/bool_function.py
@@ -70,8 +70,11 @@ class StringIsEqual(JMCFunction):
 )
 class ObjectIsEqual(JMCFunction):
     current_object = "currentObject"
+    def is_uuid(string):
+        parts = string.split('-')
+        return len(parts) == 5 and all(len(part) in (8, 4, 4, 4, 12) and part.isalnum() for part in parts)
     def get_source_type(source):
-        if source.startswith("@"):
+        if source.startswith("@") or ObjectIsEqual.is_uuid(source):
             source_type = "entity"
         elif source[0] in "~^" or source.isnumeric():
             source_type = "block"


### PR DESCRIPTION
Object.isEqual() will now only be given 4 arguments, 'source1, path1, source2 path2' 
and 
String.isEqual() now only be given 3 arguments `source, path, string` 
This is done for better readability and ease of use. All tests run succesfully. 