### PR TITLE
Using return command inside the Player.join makes it constantly run the given function.

### DIFF
--- a/src/jmc/compile/command/builtin_function/load_once.py
+++ b/src/jmc/compile/command/builtin_function/load_once.py
@@ -49,8 +49,8 @@ class PlayerJoin(JMCFunction):
             f"""execute as @a unless score @s {obj_name} = $__global__ {obj_name} run {
                 self.datapack.add_raw_private_function(self.name,
                                                        [
-                                                           self.args["function"],
-                                                           f"scoreboard players operation @s {obj_name} = $__global__ {obj_name}"
+                                                           f"scoreboard players operation @s {obj_name} = $__global__ {obj_name}",
+                                                           self.args["function"]
                                                        ], "main")}"""
         )
         return ""


### PR DESCRIPTION
When this is inputted:

```
Player.join(() => {
 say "hi";
 return 0;
});
```

In the private function normally it should put the `scoreboard players operation @s 000bi5iy7_p_join = $__global__ 000bi5iy7_p_join` line in the beginning, but it puts it in the last line causing the loop since the `return` happens before the last line.

Private function looks like this:

```
say hi
return 0
scoreboard players operation @s 000bi5iy7_p_join = $__global__ 000bi5iy7_p_join
```