### PR TITLE
Update Features.tsx

### DIFF
--- a/src/pages/BuiltInFunction/Features.tsx
+++ b/src/pages/BuiltInFunction/Features.tsx
@@ -856,7 +856,7 @@ const BuildinFeatures = [
             <code>center</code>.
         </p>
         <Command
-            name="Particle.square"
+            name="Particle.cube"
             type="JMCFunction"
             params={[
                 { key: "particle", type: "string" },


### PR DESCRIPTION
Fix typo in command example code.

Command example under `Particle.cube` is accidentally written as `Particle.square`.