### PR TITLE
Fix broken De Morgan's law for negated and clauses; add integration tests

### DIFF
--- a/src/jmc/compile/command/condition.py
+++ b/src/jmc/compile/command/condition.py
@@ -487,7 +487,19 @@ def ast_to_commands(
             if ast["body"]["operator"] == OR_OPERATOR:
                 ast["body"]["operator"] = AND_OPERATOR
             elif ast["body"]["operator"] == AND_OPERATOR:
-                ast["body"]["operator"] = OR_OPERATOR
+                # No De Morgan's law for !(A && B) condition; directly use negated AND result
+                and_conditions, and_precommand = ast_to_commands(ast["body"], datapack)
+                _count = datapack.data.condition_count
+                datapack.data.condition_count += 1
+                precommand_not: list[tuple[list[Condition], int]] = []
+                if and_precommand is not None:
+                    precommand_not.extend(and_precommand)
+                precommand_not.append((and_conditions, _count))
+
+                return [
+                    Condition(f"score {VAR}{_count} {DataPack.var_name} matches 1", UNLESS)
+                ], precommand_not
+
             conditions, precommand = ast_to_commands(ast["body"], datapack)
         else:
             raise ValueError('ast["body"] is a list or str')

--- a/src/tests/integration/test_flow_controls.py
+++ b/src/tests/integration/test_flow_controls.py
@@ -222,6 +222,53 @@ execute if score __logic__0 __variable__ matches 1 run say Hello World
         )
 
 
+    def test_negated_ands(self):
+        pack = JMCTestPack().set_jmc_file("""
+if (!(entity @e[type=skeleton] && entity @e[type=zombie] && entity @e[type=creeper])) {
+    say "Hello World";
+}
+        """).build()
+
+        self.assertDictEqual(
+            pack.built,
+            string_to_tree_dict("""
+> VIRTUAL/data/minecraft/tags/functions/load.json
+{
+    "values": [
+        "TEST:__load__"
+    ]
+}
+> VIRTUAL/data/TEST/functions/__load__.mcfunction
+scoreboard objectives add __variable__ dummy
+scoreboard players set __logic__0 __variable__ 0
+execute if entity @e[type=skeleton] if entity @e[type=zombie] if entity @e[type=creeper] run scoreboard players set __logic__0 __variable__ 1
+execute unless score __logic__0 __variable__ matches 1 run say Hello World
+            """)
+        )
+
+    def test_negated_ors(self):
+        pack = JMCTestPack().set_jmc_file("""
+if (!(entity @e[type=skeleton] || entity @e[type=zombie] || entity @e[type=creeper])) {
+    say "Hello World";
+}
+        """).build()
+
+        self.assertDictEqual(
+            pack.built,
+            string_to_tree_dict("""
+> VIRTUAL/data/minecraft/tags/functions/load.json
+{
+    "values": [
+        "TEST:__load__"
+    ]
+}
+> VIRTUAL/data/TEST/functions/__load__.mcfunction
+scoreboard objectives add __variable__ dummy
+execute unless entity @e[type=skeleton] unless entity @e[type=zombie] unless entity @e[type=creeper] run say Hello World
+            """)
+        )
+
+
 class TestFor(unittest.TestCase):
     def test_for(self):
         pack = JMCTestPack().set_jmc_file("""


### PR DESCRIPTION
Hi! This PR fixes the broken implementation of De Morgan's law when parsing `!(A && B)` clauses. 

#### Previous behavior:
```
if (!($A && $B && $C)) {
    say "hello";
}
```
builds to
```
scoreboard players set __logic__0 __variable__ 0
execute if score $A __variable__ matches 1.. run scoreboard players set __logic__0 __variable__ 1
execute unless score __logic__0 __variable__ matches 1 if score $B __variable__ matches 1.. run scoreboard players set __logic__0 __variable__ 1
execute unless score __logic__0 __variable__ matches 1 if score $C __variable__ matches 1.. run scoreboard players set __logic__0 __variable__ 1
execute unless score __logic__0 __variable__ matches 1 run say hello
```
which is more or less `!(A || B || C)` or `!A && !B && !C`

#### New behavior:
```
scoreboard players set __logic__0 __variable__ 0
execute if score $A __variable__ matches 1.. if score $B __variable__ matches 1.. if score $C __variable__ matches 1.. run scoreboard players set __logic__0 __variable__ 1
execute unless score __logic__0 __variable__ matches 1 run say hello
```
which just negates the AND clause. I think this is the better option for fixing this behavior versus implementing De Morgan's properly since the two liner feels faster to me than chaning execute commands together for an OR block.

I've added two integration tests to watch for changes in this behavior. This is my first PR on the project; please let me know if I need to create issues first or anything.