### PR TITLE
Add stderr routing for printed errors; clean up color handling; add pprint hooks for compile-time messages

### DIFF
--- a/src/jmc/__main__.py
+++ b/src/jmc/__main__.py
@@ -6,14 +6,13 @@ import shutil
 import subprocess
 import argparse
 import importlib.util
+import os
 from pathlib import Path
 import sys
 
 
-from .terminal.configuration import Configuration
 from .compile import Logger
-from .terminal.utils import RestartException, handle_exception
-from .terminal import GlobalData, Colors, start
+from .terminal import Colors, Configuration, eprint, handle_exception, pprint, RestartException, GlobalData, start
 from .config import VERSION, CONFIG_FILE_NAME
 
 GlobalData().init(VERSION, CONFIG_FILE_NAME)
@@ -29,6 +28,7 @@ PACKAGE_SOURCE = "git+https://github.com/WingedSeal/jmc.git#subdirectory=src"
 
 def main():
     """Main function"""
+    os.system("")  # required for ANSI escape codes on Windows terminal
     logger.info(f"Argv: {sys.argv}")
     args = get_args()
     logger.info(f"Args: {args}")
@@ -39,7 +39,7 @@ def main():
     elif args.command == "config":
         config(args)
     elif args.command == "run" or args.command is None:
-        atexit.register(lambda: print(Colors.EXIT.value + "\n"))
+        atexit.register(lambda: sys.stdout.isatty() and print(Colors.EXIT.value + "\n"))
         run()
     elif args.command == "update":
         update(args)
@@ -127,7 +127,7 @@ def init(args: argparse.Namespace):
     if args.output is None:
         configuration.output = configuration._default_output()
     if not args.is_force and configuration.is_file_exist():
-        print(
+        eprint(
             "Initialization failed: Configuration file already exists. Run with `--force` to override the old file."
         )
         return
@@ -143,11 +143,11 @@ def update(args: argparse.Namespace):
     """Update the CLI package to the latest version via pip"""
     git_version_detected = VERSION.endswith("-git")
     if git_version_detected:
-        print("Git version detected")
+        pprint("Git version detected")
         if args.is_git:
-            print("Ignoring '--git' flag")
+            pprint("Ignoring '--git' flag")
     elif args.is_git:
-        print("Forcing git version")
+        pprint("Forcing git version")
     is_git = args.is_git or git_version_detected
     updater = _get_updater()
     if updater == Updater.PIP:
@@ -178,30 +178,30 @@ def update(args: argparse.Namespace):
 
     try:
         subprocess.check_call(command)
-        print("Update installed")
+        pprint("Update installed")
     except subprocess.CalledProcessError as e:
-        print(f"Update failed: {e}")
+        eprint(f"Update failed: {e}")
         sys.exit(1)
 
 
 def _get_updater() -> Updater:
     if importlib.util.find_spec("pip") is not None:
-        print("Module 'pip' found, updating...")
+        pprint("Module 'pip' found, updating...")
         return Updater.PIP
-    print("Module 'pip' not found, falling back to 'uv' command")
+    pprint("Module 'pip' not found, falling back to 'uv' command")
     if shutil.which("uv") is not None:
-        print("command 'uv' found")
+        pprint("command 'uv' found")
         try:
             result = subprocess.run(
                 ["uv", "tool", "list"], capture_output=True, text=True, check=True
             )
             if PACKAGE_NAME in result.stdout:
-                print(f"'{PACKAGE_NAME}' package found in 'uv', updating...")
+                pprint(f"'{PACKAGE_NAME}' package found in 'uv', updating...")
                 return Updater.UV
         except subprocess.CalledProcessError:
             pass
-        print(f"'{PACKAGE_NAME}' package not found in 'uv'")
-    print("Update failed")
+        eprint(f"'{PACKAGE_NAME}' package not found in 'uv'")
+    eprint("Update failed")
     sys.exit(1)
 
 
@@ -209,7 +209,7 @@ def config(args: argparse.Namespace):
     configuration = global_data.config
     configuration.load_config()
     if not configuration.is_file_exist():
-        print("Configuration editing failed: Configuration file does not exists.")
+        eprint("Configuration editing failed: Configuration file does not exist.")
         return
     setattr(configuration, args.config, args.value)
     configuration.save_config()
@@ -217,7 +217,7 @@ def config(args: argparse.Namespace):
 
 def compile(args: argparse.Namespace):
     if not global_data.config.is_file_exist():
-        print("Compilation failed: Configuration file does not exists.")
+        eprint("Compilation failed: Configuration file does not exist.")
         return
     global_data.config.load_config()
     terminal_commands.compile_(*args.environment)

--- a/src/jmc/api/_py_jmc.py
+++ b/src/jmc/api/_py_jmc.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from ..compile.datapack import DataPack
 from ..compile.lexer import Lexer
 
-from ..terminal.configuration import Configuration, GlobalData
+from ..terminal import Configuration, GlobalData
 from ..compile.header import Header
 from ..compile.compiling import cert_config_to_string, read_cert, read_header, build
 

--- a/src/jmc/compile/command/builtin_function/jmc_command.py
+++ b/src/jmc/compile/command/builtin_function/jmc_command.py
@@ -13,6 +13,7 @@ from ...exception import (
     JMCValueError,
     relative_file_name,
 )
+from ...hooks import emit_message
 from ..utils import ArgType, NumberType, find_scoreboard_player_type
 from ..jmc_function import JMCFunction, FuncType, func_property
 from .utils.isolated import IsolatedEnvironment
@@ -231,13 +232,10 @@ class JMCLog(JMCFunction):
     def call(self) -> str:
         text = self.args["text"]
         if "\n" not in text:
-            print(f"JMC.log: {text}")
+            emit_message(f"JMC.log: {text}")
         else:
-            print(
-                "\n".join(
-                    f"JMC.log[{i}]: {text}" for i, text in enumerate(text.split("\n"))
-                )
-            )
+            for i, line in enumerate(text.split("\n")):
+                emit_message(f"JMC.log[{i}]: {line}")
         return ""
 
 
@@ -252,14 +250,10 @@ class JMCLogAny(JMCFunction):
     def call(self) -> str:
         text = self.args["prefix"] + self.args["any"]
         if "\n" not in text:
-            print(f"JMC.logAny: {text}")
+            emit_message(f"JMC.logAny: {text}")
         else:
-            print(
-                "\n".join(
-                    f"JMC.logAny[{i}]: {text}"
-                    for i, text in enumerate(text.split("\n"))
-                )
-            )
+            for i, line in enumerate(text.split("\n")):
+                emit_message(f"JMC.logAny[{i}]: {line}")
         return ""
 
 
@@ -273,9 +267,7 @@ class JMCLogAny(JMCFunction):
 class JMCTodo(JMCFunction):
     def call(self) -> str:
         self.self_token
-        print(
-            f"JMC.todo({relative_file_name(self.tokenizer.file_path, self.self_token.line, self.self_token.col)}): {self.args['text']}"
-        )
+        emit_message(f"JMC.todo({relative_file_name(self.tokenizer.file_path, self.self_token.line, self.self_token.col)}): {self.args['text']}")
         return ""
 
 

--- a/src/jmc/compile/header_parse.py
+++ b/src/jmc/compile/header_parse.py
@@ -17,7 +17,7 @@ from .exception import (
 from .log import Logger
 
 if TYPE_CHECKING:
-    from ..terminal.configuration import Configuration
+    from ..terminal import Configuration
     from ..compile.datapack import DataPack
 
 logger = Logger(__name__)

--- a/src/jmc/compile/hooks.py
+++ b/src/jmc/compile/hooks.py
@@ -1,0 +1,23 @@
+from typing import Callable
+
+_message_handler: Callable[[str], None] = print
+
+
+def register_message(fn: Callable[[str], None]) -> None:
+    """Register a handler for user-facing compile-time messages.
+
+    This hook avoids a circular import and prevents the compile module from knowing specifics of how output is rendered.
+    Note: Must be called before compilation begins. Not thread-safe to call concurrently with emit_message.
+
+    :param fn: lambda which receives the message string and renders it.
+    """
+    global _message_handler
+    _message_handler = fn
+
+
+def emit_message(message: str) -> None:
+    """Emit a user-facing message through the registered handler.
+
+    :param message: The message string to emit.
+    """
+    _message_handler(message)

--- a/src/jmc/compile/test_compile.py
+++ b/src/jmc/compile/test_compile.py
@@ -3,7 +3,7 @@
 from json import dumps
 from pathlib import Path
 
-from ..terminal.configuration import Configuration, GlobalData
+from ..terminal import Configuration, GlobalData
 from .log import Logger
 from .header import Header
 from .compiling import read_cert, read_header, build

--- a/src/jmc/terminal/__init__.py
+++ b/src/jmc/terminal/__init__.py
@@ -1,3 +1,3 @@
 from .configuration import GlobalData, Configuration, add_command
-from .utils import Colors, handle_exception, pprint
+from .utils import Colors, eprint, error_report, get_input, handle_exception, press_enter, pprint, RestartException
 from .main import start

--- a/src/jmc/terminal/configuration.py
+++ b/src/jmc/terminal/configuration.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 import threading
 from typing import Any, Callable, TypeVar
-from .utils import Colors, get_input, pprint
+from .utils import Colors, eprint, get_input, pprint
 from ..compile.utils import SingleTon, is_float
 from ..compile import Logger
 from dataclasses import dataclass
@@ -70,7 +70,7 @@ def get_pack_format(string: str) -> str:
     """
     if "." not in string:
         if not string.isdigit():
-            pprint("Invalid Pack Format: Non float detected.", Colors.FAIL)
+            eprint("Invalid Pack Format: Non float detected.")
             return ""
         return string
 
@@ -83,26 +83,20 @@ def get_pack_format(string: str) -> str:
 
     string_split = string.split(".")
     if not 2 <= len(string_split) <= 3:
-        pprint(
-            f"Invalid Minecraft version: Expect 1 or 2 dot (got {len(string_split) - 1}).",
-            Colors.FAIL,
-        )
+        eprint(f"Invalid Minecraft version: Expect 1 or 2 dot (got {len(string_split) - 1}).")
         return ""
 
     try:
         current_version = MinecraftVersion(*(int(x) for x in string_split))
     except ValueError:
-        pprint("Invalid Minecraft version: Non integer detected.", Colors.FAIL)
+        eprint("Invalid Minecraft version: Non integer detected.")
         return ""
 
     for minecraft_version, pack_format in PACK_VERSION.items():
         if current_version > minecraft_version:
             return pack_format
 
-    pprint(
-        f"Invalid Minecraft version: Version {current_version} does not support datapack.",
-        Colors.FAIL,
-    )
+    eprint(f"Invalid Minecraft version: Version {current_version} does not support datapack.")
     return ""
 
 
@@ -181,16 +175,10 @@ class Configuration:
             self.output = self.global_data.cwd / json["output"]
             self.is_configed = True
         except JSONDecodeError as error:
-            pprint(
-                f"Invalid JSON syntax in {self.global_data.CONFIG_FILE_NAME}. Delete the file to reset the configuration.",
-                Colors.FAIL,
-            )
+            eprint(f"Invalid JSON syntax in {self.global_data.CONFIG_FILE_NAME}. Delete the file to reset the configuration.")
             raise error from error
         except KeyError as error:
-            pprint(
-                f"Invalid JSON data in {self.global_data.CONFIG_FILE_NAME}. Delete the file to reset the configuration.",
-                Colors.FAIL,
-            )
+            eprint(f"Invalid JSON data in {self.global_data.CONFIG_FILE_NAME}. Delete the file to reset the configuration.")
             raise error from error
 
     def save_config(self):
@@ -226,16 +214,13 @@ class Configuration:
         while True:
             namespace = get_input("Namespace(Leave blank to cancel): ")
             if " " in namespace or "\t" in namespace:
-                pprint("Invalid Namespace: Space detected.", Colors.FAIL)
+                eprint("Invalid Namespace: Space detected.")
                 continue
             if namespace == "":
-                pprint(
-                    f"Configuration canceled.{' Using backup configuration.' if self.is_configed else ''}",
-                    Colors.FAIL,
-                )
+                eprint(f"Configuration canceled.{' Using backup configuration.' if self.is_configed else ''}")
                 return
             if not namespace.islower():
-                pprint("Invalid Namespace: Uppercase character detected.", Colors.FAIL)
+                eprint("Invalid Namespace: Uppercase character detected.")
                 continue
             break
         self.namespace = namespace
@@ -261,12 +246,12 @@ class Configuration:
                 target = self._default_target()
                 break
             if not target_str.endswith(".jmc"):
-                pprint("Invalid path: Target file needs to end with .jmc", Colors.FAIL)
+                eprint("Invalid path: Target file needs to end with .jmc")
                 continue
             try:
                 target = Path(target_str).resolve()
             except BaseException:
-                pprint("Invalid path", Colors.FAIL)
+                eprint("Invalid path")
                 continue
             break
         target.touch(exist_ok=True)
@@ -283,10 +268,10 @@ class Configuration:
             try:
                 output = Path(output_str).resolve()
                 if output.is_file():
-                    pprint("Path is not a directory.", Colors.FAIL)
+                    eprint("Path is not a directory.")
                     continue
             except BaseException:
-                pprint("Invalid path", Colors.FAIL)
+                eprint("Invalid path")
                 continue
             break
         self.output = output

--- a/src/jmc/terminal/main.py
+++ b/src/jmc/terminal/main.py
@@ -1,6 +1,5 @@
-import os
 from .configuration import GlobalData
-from .utils import Colors, get_input, pprint
+from .utils import Colors, eprint, get_input, pprint
 from ..compile import Logger
 
 logger = Logger(__name__)
@@ -9,7 +8,7 @@ global_data: GlobalData = GlobalData()
 
 
 def unknown_command(*args, **kwargs) -> None:
-    pprint("Command not recognized, try `help` for more info.", Colors.FAIL)
+    eprint("Command not recognized, try `help` for more info.")
 
 
 def handle_command(given_command: str) -> None:
@@ -22,12 +21,11 @@ def handle_command(given_command: str) -> None:
     except TypeError as error:
         msg: str = error.args[0]
         msg = msg.replace("()", " command").replace("positional argument", "argument")
-        pprint(msg, Colors.FAIL)
-        pprint(f"Usage: {usage}", Colors.FAIL)
+        eprint(msg)
+        eprint(f"Usage: {usage}")
 
 
 def start() -> None:
-    os.system("")
     logger.info(f"Build-version: {global_data.VERSION}")
     pprint(f" JMC Compiler {global_data.VERSION}\n", Colors.HEADER)
     pprint(f"Current Directory | {global_data.cwd}\n", Colors.YELLOW)

--- a/src/jmc/terminal/utils.py
+++ b/src/jmc/terminal/utils.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from getpass import getpass
+import sys
 from threading import Event
 from traceback import format_exc
 from ..compile import Logger
@@ -8,38 +9,55 @@ logger = Logger(__name__)
 
 
 class Colors(Enum):
-    HEADER = "\033[1;33;40m"
-    YELLOW = "\033[33;40m"
-    INFO = "\033[94;40m"
-    INPUT = "\033[96;40m"
-    PURPLE = "\033[35;40m"
-    FAIL = "\033[91;40m"
-    FAIL_BOLD = "\033[1;91;40m"
-    ENDC = "\033[0;0;40m"
-    EXIT = "\033[0;0;0m"
-    NONE = "\033[0;37;40m"
+    HEADER = "\033[1;33m"
+    YELLOW = "\033[33m"
+    INFO = "\033[94m"
+    INPUT = "\033[96m"
+    PURPLE = "\033[35m"
+    FAIL = "\033[91m"
+    FAIL_BOLD = "\033[1;91m"
+    ENDC = "\033[0m"
+    EXIT = "\033[0m"
+    NONE = "\033[0m"
 
 
-def pprint(values, color: Colors = Colors.NONE):
+def pprint(values, color: Colors = Colors.NONE, file=sys.stdout):
     """
-    Print but with colors
+    Print colored text
 
-    :param values: Value for printing
-    :param color: color of printing
+    :param values: Output text
+    :param color: Output color (defaults to no color)
+    :param file: Where to print (defaults to stdout)
     """
-    print(f"{color.value}{values}{Colors.ENDC.value}")
+    if file.isatty():
+        print(f"{color.value}{values}{Colors.ENDC.value}", file=file)
+    else:
+        print(values, file=file)
+
+
+def eprint(values, color: Colors = Colors.FAIL):
+    """
+    Print error message to stderr
+
+    :param values: Error text
+    :param color: Error color (defaults to Colors.FAIL)
+    """
+    pprint(values, color, file=sys.stderr)
 
 
 def get_input(prompt: str = "> ", color: Colors = Colors.INPUT) -> str:
     """
     Get an input from user
 
-    :param promt: Display string infront
+    :param prompt: Display string infront
     :param color: Color of the input and promt
     :return: input from user
     """
-    input_value = input(f"{color.value}{prompt}")
-    print(Colors.ENDC.value, end="")
+    if sys.stdout.isatty():
+        input_value = input(f"{color.value}{prompt}")
+        print(Colors.ENDC.value, end="", flush=True)
+    else:
+        input_value = input(prompt)
     logger.info(f"Input from user: {input_value}")
     return input_value
 
@@ -55,32 +73,19 @@ def press_enter(prompt: str, color: Colors = Colors.INPUT) -> None:
 
 
 def error_report(error: Exception) -> None:
-    """
-    Report error to user
-
-    :param error: Exception for reporting
-    """
-    pprint(type(error).__name__, Colors.FAIL_BOLD)
-    pprint(error, Colors.FAIL)
+    eprint(type(error).__name__, Colors.FAIL_BOLD)
+    eprint(error)
 
 
 def handle_exception(error: Exception, event: Event, is_ok: bool):
-    """
-    Tell user when unexpected crash happens and reset
-
-    :param error: Exception
-    :param event: Event object to stop compiling
-    :param is_ok: Whether to tell user this error is normal
-    """
     event.set()
-    pprint("Unexpected error causes program to crash", Colors.FAIL)
-    pprint(type(error).__name__, Colors.FAIL_BOLD)
-    pprint(error, Colors.FAIL)
+    eprint("An unexpected error caused the program to crash")
+    eprint(type(error).__name__, Colors.FAIL_BOLD)
+    eprint(error)
     if not is_ok:
-        pprint(format_exc(), Colors.YELLOW)
-        pprint(
-            "Please report this error at https://github.com/WingedSeal/jmc/issues/new/choose or https://discord.gg/PNWKpwdzD3.",
-            Colors.FAIL)
+        eprint(format_exc(), Colors.YELLOW)
+        eprint(
+            "Please report this error at https://github.com/WingedSeal/jmc/issues/new/choose or https://discord.gg/PNWKpwdzD3.")
     logger.critical("Program crashed")
     logger.exception("")
     press_enter("Press Enter to continue...")

--- a/src/jmc/terminal_commands.py
+++ b/src/jmc/terminal_commands.py
@@ -9,9 +9,8 @@ from time import perf_counter
 from traceback import format_exc
 
 from .compile.header import Header
-
-from .terminal.utils import RestartException, error_report, get_input, handle_exception, press_enter
-from .terminal import pprint, Colors, GlobalData, add_command
+from .compile.hooks import register_message
+from .terminal import GlobalData, add_command, Colors, eprint, error_report, get_input, handle_exception, press_enter, pprint, RestartException
 from .compile import compile_jmc, Logger, EXCEPTIONS, get_debug_log, get_info_log
 
 global_data: GlobalData = GlobalData()
@@ -47,7 +46,7 @@ def exit_() -> None:
 @add_command("compile [env ...]", "compile")
 def compile_(*envs: str) -> None:
     """Compile main JMC file"""
-
+    register_message(lambda msg: pprint(msg, Colors.YELLOW))
     pprint("Compiling...", Colors.INFO)
     if not global_data.config:
         global_data.config.ask_and_save()
@@ -129,7 +128,7 @@ def version() -> None:
 def __config_reset() -> None:
     (global_data.cwd / global_data.CONFIG_FILE_NAME).unlink(missing_ok=True)
     pprint("Resetting configurations", Colors.PURPLE)
-    print("\n" * 5)
+    pprint("\n" * 5)
     raise RestartException()
 
 
@@ -142,7 +141,7 @@ Type `cancel` to cancel
     if key not in config_json:
         if key.lower() == "cancel":
             return
-        pprint("Invalid Key", Colors.FAIL)
+        eprint("Invalid Key")
         __config_edit()
     else:
         pprint(f"Current {key}: {config_json[key]}", Colors.YELLOW)
@@ -162,9 +161,7 @@ def config(mode: str = "") -> None:
         if not global_data.config:
             global_data.config.ask_and_save()
             return
-        pprint(
-            "Configuration file is already generated. To reset, use `cofig reset`",
-            Colors.FAIL)
+        eprint("Configuration file is already generated. To reset, use `cofig reset`")
     if mode == "reset":
         __config_reset()
     elif mode == "edit":
@@ -188,7 +185,7 @@ def autocompile(interval: str) -> None:
     except ValueError as error:
         raise TypeError("Invalid integer for interval") from error
     if global_data.interval == 0:
-        pprint("Interaval cannot be 0 seconds", Colors.FAIL)
+        eprint("Interval cannot be 0 seconds")
         return
 
     if not global_data.config:
@@ -214,7 +211,7 @@ def chdir(path: str) -> None:
     try:
         os.chdir(path)
     except (ValueError, FileNotFoundError):
-        pprint("Invalid path", Colors.FAIL)
+        eprint("Invalid path")
         return
     global_data.cwd = Path(os.getcwd())
     global_data.LOG_PATH = global_data.cwd / "log"

--- a/src/tests/unit/__init__.py
+++ b/src/tests/unit/__init__.py
@@ -1,4 +1,4 @@
 from types import ModuleType as __ModuleType
-from . import test_tokenizer, test_utils
-ALL: tuple[__ModuleType, ...] = (test_tokenizer,
+from . import test_terminal, test_tokenizer, test_utils
+ALL: tuple[__ModuleType, ...] = (test_terminal, test_tokenizer,
                                  test_utils)

--- a/src/tests/unit/test_terminal.py
+++ b/src/tests/unit/test_terminal.py
@@ -1,0 +1,58 @@
+import sys  # noqa
+
+sys.path.append("./src")  # noqa
+import io  # noqa
+import unittest  # noqa
+
+from jmc.compile.hooks import emit_message, register_message
+from jmc.terminal.utils import Colors, eprint, pprint
+
+
+class TestHooks(unittest.TestCase):
+    def test_default_handler_is_print(self):
+        from jmc.compile import hooks
+        self.assertIs(hooks._message_handler, print)
+
+    def test_register_replaces_handler(self):
+        received: list[str] = []
+        register_message(received.append)
+        emit_message("hello")
+        self.assertEqual(received, ["hello"])
+
+    def test_emit_calls_through_handler(self):
+        received: list[str] = []
+        register_message(received.append)
+        emit_message("one")
+        emit_message("two")
+        self.assertEqual(received, ["one", "two"])
+
+    def tearDown(self):
+        register_message(print)
+
+
+class TestPprint(unittest.TestCase):
+    def test_no_colors_on_non_tty(self):
+        buf = io.StringIO()
+        pprint("hello", Colors.INFO, file=buf)
+        self.assertEqual(buf.getvalue(), "hello\n")
+
+    def test_colors_on_tty(self):
+        buf = io.StringIO()
+        buf.isatty = lambda: True
+        pprint("hello", Colors.INFO, file=buf)
+        self.assertIn(Colors.INFO.value, buf.getvalue())
+        self.assertIn(Colors.ENDC.value, buf.getvalue())
+
+
+class TestEprint(unittest.TestCase):
+    def test_writes_to_stderr(self):
+        stderr_buf = io.StringIO()
+        stdout_buf = io.StringIO()
+        old_stderr, old_stdout = sys.stderr, sys.stdout
+        sys.stderr, sys.stdout = stderr_buf, stdout_buf
+        try:
+            eprint("error message")
+        finally:
+            sys.stderr, sys.stdout = old_stderr, old_stdout
+        self.assertIn("error message", stderr_buf.getvalue())
+        self.assertEqual(stdout_buf.getvalue(), "")


### PR DESCRIPTION
Hi! I refactored a lot in this PR but with the purpose of keeping existing functionality as similar as possible to the current JMC tool. Please let me know if any of the following changes went too far and I'd be happy to revert changes or meet in the middle.

#### Changes made to printing: 
- `pprint` is used wherever possible throughout JMC.
- Added a message hook for the `compile` module so that it can use `pprint`. From what I can tell this is standard practice for other Python modules. This can be extended in the future if `compile` needs to pass more info back to the `terminal` module.
- Added `eprint` for error messages. By default this prints to stderr.
- Color data should now always be cleaned up on exit.
- ANSI escape codes are no longer emitted in non-TTY contexts.
- Removed black text backgrounds.
- Added `os.system("")` to main function so that interactive and non-interactive modes both have color on Windows 10 terminal.
- Cleaned up terminal module imports to all be top-level. Left compile module imports alone since this is out of scope.
- Overall grammar pass ("Configuration file does not exists." -> "Configuration file does not exist.")
- Added unit tests for the major additions + corrected edge cases. Most changes remain untested since terminal color isn't really that big of a deal :)
- Unstyled `Colors.NONE` for better readability in light terminals.