### PR TITLE
Fix FileNotFoundError when missing config

### DIFF
--- a/src/jmc/__main__.py
+++ b/src/jmc/__main__.py
@@ -218,6 +218,7 @@ def config(args: argparse.Namespace):
 def compile(args: argparse.Namespace):
     if not global_data.config.is_file_exist():
         print("Compilation failed: Configuration file does not exists.")
+        return
     global_data.config.load_config()
     terminal_commands.compile_(*args.environment)
 


### PR DESCRIPTION
This PR fixes a FileNotFoundError I ran across when making my last PR. End execution before the config file is requested.

#### Previous behavior:
```
📦[quinn@fedora QuinnDataPack]$ jmc compile
Compilation failed: Configuration file does not exist.
Traceback (most recent call last):
  File "/home/quinn/.local/bin/jmc", line 8, in <module>

...

FileNotFoundError: [Errno 2] No such file or directory: '/home/quinn/Projects/QuinnDataPack/jmc_config.json'
```

#### New behavior:
```
📦[quinn@fedora QuinnDataPack]$ jmc compile
Compilation failed: Configuration file does not exist.
```