### PR TITLE
Fix out of bounds when Python generated content adds lines to source file and jmc=true

### DIFF
--- a/src/jmc/compile/command/builtin_function/jmc_command.py
+++ b/src/jmc/compile/command/builtin_function/jmc_command.py
@@ -1353,6 +1353,7 @@ class EntityLaunch(JMCFunction):
 
 
 ISOLATED_ENVIRONMENT = IsolatedEnvironment("emit")
+JMC_PY_FILE_PATH_SUFFIX = "#python_generated_content"
 
 
 @func_property(
@@ -1406,6 +1407,8 @@ class JMCPythonFile(JMCFunction):
                         Token(TokenType.PAREN_CURLY, 0, 0, f"{{\n{output}\n}}"),
                         self.tokenizer,
                         self.prefix,
+                        file_string=output,
+                        file_path=self.tokenizer.file_path + JMC_PY_FILE_PATH_SUFFIX,
                     )
                 )
             except EXCEPTIONS as error:
@@ -1480,6 +1483,8 @@ class JMCPython(JMCFunction):
                         Token(TokenType.PAREN_CURLY, 0, 0, f"{{\n{output}\n}}"),
                         self.tokenizer,
                         self.prefix,
+                        file_string=output,
+                        file_path=self.tokenizer.file_path + JMC_PY_FILE_PATH_SUFFIX,
                     )
                 )
             except EXCEPTIONS as error:

--- a/src/jmc/compile/datapack.py
+++ b/src/jmc/compile/datapack.py
@@ -571,13 +571,20 @@ class DataPack:
         return self.call_func(name, count)
 
     def parse_function_token(
-        self, token: Token | list[Token], tokenizer: Tokenizer, prefix: str
+        self,
+        token: Token | list[Token],
+        tokenizer: Tokenizer,
+        prefix: str,
+        file_string: str | None = None,
+        file_path: str | None = None,
     ) -> list[str]:
         """
         "Parse a paren_curly token into a list of commands(string)
 
         :param token: paren_curly token
         :param tokenizer: token's tokenizer
+        :param file_string: Override file_string for the inner tokenizer (use when token content is generated, not from the original source)
+        :param file_path: Override file_path for the inner tokenizer (use when token content is generated, not from the original source)
         :return: List of minecraft commands(string)
         """
         if isinstance(token, list):
@@ -586,10 +593,10 @@ class DataPack:
             )
         return self.lexer.parse_func_content(
             token.string[1:-1],
-            tokenizer.file_path,
+            file_path if file_path is not None else tokenizer.file_path,
             token.line,
             token.col,
-            tokenizer.file_string,
+            file_string if file_string is not None else tokenizer.file_string,
             prefix,
         )
 

--- a/src/tests/integration/test_jmc_function.py
+++ b/src/tests/integration/test_jmc_function.py
@@ -1193,5 +1193,84 @@ scoreboard players set @a[tag=test] test 1
 #             """).build()
 
 
+class TestJMCPython(unittest.TestCase):
+    def test_basic_emit(self):
+        pack = (
+            JMCTestPack()
+            .set_jmc_file(
+                """
+JMC.python(`
+    for i in range(3):
+        emit(f'say {i}')
+`);
+            """
+            )
+            .build()
+        )
+        self.assertDictEqual(
+            pack.built,
+            string_to_tree_dict(
+                """
+> VIRTUAL/data/minecraft/tags/functions/load.json
+{
+    "values": [
+        "TEST:__load__"
+    ]
+}
+> VIRTUAL/data/TEST/functions/__load__.mcfunction
+scoreboard objectives add __variable__ dummy
+say 0
+say 1
+say 2
+            """
+            ),
+        )
+
+    def test_jmc_true_compiles_generated_output(self):
+        pack = (
+            JMCTestPack()
+            .set_jmc_file(
+                """
+JMC.python(`
+    emit('$result = 5;')
+`, jmc=true);
+            """
+            )
+            .build()
+        )
+        load = pack.built["VIRTUAL/data/TEST/functions/__load__.mcfunction"]
+        self.assertIn("scoreboard players set $result __variable__ 5", load)
+
+    def test_jmc_true_output_longer_than_source(self):
+        # Ensures generated content can have more lines than the source file. 
+        # parse_function_token must use generated content as file_string.
+        pack = (
+            JMCTestPack()
+            .set_jmc_file(
+                """
+JMC.python(`
+    for i in range(100):
+        emit(f'$x = {i};')
+`, jmc=true);
+            """
+            )
+            .build()
+        )
+        load = pack.built["VIRTUAL/data/TEST/functions/__load__.mcfunction"]
+        self.assertIn("scoreboard players set $x __variable__ 0", load)
+        self.assertIn("scoreboard players set $x __variable__ 99", load)
+
+    def test_jmc_true_bad_generated_jmc_raises_JMCValueError(self):
+        # Error in generated content must indicate it is python_generated_content in the filepath
+        with self.assertRaisesRegex(JMCValueError, "#python_generated_content"):
+            JMCTestPack().set_jmc_file(
+                """
+JMC.python(`
+    emit('not_a_valid_command blah blah')
+`, jmc=true);
+            """
+            ).build()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When `jmc=true` in `JMC.python` and `JMC.pythonFile` builtins, any code which emits more lines than the builtin takes up will throw an index out of bounds error on compile.

#### Reproducer:
```
JMC.python(`
    for i in range(100):
        emit(f'$x = {i};')
`, jmc=true);
```
will cause a lot more lines to be added to the source file. `jmc=true` causes these lines to be parsed by the tokenizer, leading to:
```
Traceback (most recent call last):

...
  
  File "/home/quinn/Projects/jmc/src/jmc/compile/command/var_operation.py", line 57, in variable_operation
    tokenizer.file_string.split("\n")[tokens[0].line - 1],
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
IndexError: list index out of range
```

#### Changes introduced:
This PR adds `file_string` and `file_path` to `parse_function_token`, which allows generated content using `jmc=true` to use its own filepath and content string during tokenization. This appears to work quite well, with errors both before and after the JMC.python and JMC.pythonFile blocks reporting accurate line numbers. Errors inside the Python block will report a synthetic filepath and line number (accurate to position in the generated source):
```
JMCValueError
In jmc_source/terrain/heightmap_pass.jmc:120:20
A JMC exception occured in JMC.python when parsing jmc at line 120 col 20.
119 |    function get_height() {
120 |        JMC.python(`
                        ^
121 |            import math
In jmc_source/terrain/heightmap_pass.jmc#python_generated_content:645:1
Unrecognized command (foo) at line 645 col 1.
```

Claude doesn't believe any of the Hardcode builtins can lead to the same conditions. I'm a little more skeptical. Please review this carefully. I've also added a few integration tests for coverage of the new functionality in this PR. Please vet them.