### PR TITLE
Deduplicate easy-fix compiler components; remove whitespace, dead code

### DIFF
--- a/src/jmc/compile/command/builtin_function/jmc_command.py
+++ b/src/jmc/compile/command/builtin_function/jmc_command.py
@@ -1432,7 +1432,7 @@ class JMCPython(JMCFunction):
         if not string:
             return string
         if string.startswith(indent):
-            return string[len(indent) :]
+            return string[len(indent):]
         raise JMCSyntaxException(
             "Invalid indentation when trimming indentation",
             self.raw_args["pythonCode"].token,

--- a/src/jmc/compile/command/builtin_function/load_only.py
+++ b/src/jmc/compile/command/builtin_function/load_only.py
@@ -7,7 +7,7 @@ from ...header import Header
 from ...pack_version import PackVersionFeature
 from ...utils import convention_jmc_to_mc
 from ..jmc_function_mixin import EventMixin, ItemMixin
-from ...tokenizer import Token, TokenType
+from ...tokenizer import Token, Tokenizer, TokenType
 from ...exception import JMCSyntaxException, JMCMissingValueError, JMCValueError
 from ...datapack_data import GUI, SIMPLE_JSON_BODY, GUIMode, Item
 from ...datapack import DataPack
@@ -71,7 +71,6 @@ class RightClickSetup(EventMixin):
     tag_id_var = "__item_id__"
 
     def call(self) -> str:
-        # self.rc_obj = "__rc__" + self.args["idName"][:10]
         func_map = self.datapack.parse_func_map(
             self.raw_args["functionMap"].token, self.tokenizer, self.prefix
         )
@@ -709,9 +708,6 @@ class RecipeTable(JMCFunction):
 
         json = self.load_arg_json("recipe")
 
-        # raise JMCSyntaxException("'result' key not found in recipe",
-        # self.raw_args["recipe"].token, self.tokenizer,
-        # display_col_length=True, suggestion="recipe json maybe invalid")
         if "result" in json:
             if "item" not in json["result"]:
                 raise JMCSyntaxException(
@@ -1152,8 +1148,6 @@ class GUICreate(JMCFunction):
             self.datapack.private_name}/gui/{name}"
 
         reset_commands = gui.get_reset_commands()
-        # reset_commands.append("kill @e[type=minecraft:item,nbt={Item:{tag:{__gui__:{name:%s}}}}]" % repr(
-        #     name),)
         reset = self.datapack.add_raw_private_function(
             f"gui/{name}", reset_commands, "reset"
         )
@@ -1255,6 +1249,26 @@ class TeamAdd(JMCFunction):
         return command
 
 
+def _validate_single_command(
+    command: list[str], call_string: str, token: Token, tokenizer: Tokenizer
+) -> None:
+    if not command:
+        raise JMCValueError("Unexpected empty arrow function", token, tokenizer)
+    if len(command) > 1:
+        raise JMCValueError(
+            f"'{call_string}' only allows 1 command (got {len(command)})",
+            token,
+            tokenizer,
+        )
+    if command[0].startswith("say"):
+        raise JMCValueError(
+            f"'{call_string}' doesn't allow 'say' command",
+            token,
+            tokenizer,
+            suggestion="This is due to minecraft's limitation",
+        )
+
+
 @func_property(
     func_type=FuncType.LOAD_ONLY,
     call_string="TextProp.clickCommand",
@@ -1274,27 +1288,9 @@ class TextPropClickCommand(JMCFunction):
         command = self.datapack.parse_function_token(
             self.raw_args["function"].token, self.tokenizer, self.prefix
         )
-        if not command:
-            raise JMCValueError(
-                "Unexpected empty arrow function",
-                self.raw_args["function"].token,
-                self.tokenizer,
-            )
-        if len(command) > 1:
-            raise JMCValueError(
-                f"'{
-                    self.call_string}' only allows 1 command (got {
-                    len(command)})",
-                self.raw_args["function"].token,
-                self.tokenizer,
-            )
-        if command[0].startswith("say"):
-            raise JMCValueError(
-                f"'{self.call_string}' doesn't allow 'say' command",
-                self.raw_args["function"].token,
-                self.tokenizer,
-                suggestion="This is due to minecraft's limitation",
-            )
+        _validate_single_command(
+            command, self.call_string, self.raw_args["function"].token, self.tokenizer
+        )
 
         if self.datapack.version < PackVersionFeature.TEXT_COMPONENT:
             outer_key, inner_key = "clickEvent", "value"
@@ -1328,27 +1324,9 @@ class TextPropsClickCommand(JMCFunction):
         command = self.datapack.parse_function_token(
             self.raw_args["function"].token, self.tokenizer, self.prefix
         )
-        if not command:
-            raise JMCValueError(
-                "Unexpected empty arrow function",
-                self.raw_args["function"].token,
-                self.tokenizer,
-            )
-        if len(command) > 1:
-            raise JMCValueError(
-                f"'{
-                    self.call_string}' only allows 1 command (got {
-                    len(command)})",
-                self.raw_args["function"].token,
-                self.tokenizer,
-            )
-        if command[0].startswith("say"):
-            raise JMCValueError(
-                f"'{self.call_string}' doesn't allow 'say' command",
-                self.raw_args["function"].token,
-                self.tokenizer,
-                suggestion="This is due to minecraft's limitation",
-            )
+        _validate_single_command(
+            command, self.call_string, self.raw_args["function"].token, self.tokenizer
+        )
 
         if self.datapack.version < PackVersionFeature.TEXT_COMPONENT:
             outer_key, inner_key = "clickEvent", "value"
@@ -1385,27 +1363,9 @@ class TextPropSuggestCommand(JMCFunction):
         command = self.datapack.parse_function_token(
             self.raw_args["function"].token, self.tokenizer, self.prefix
         )
-        if not command:
-            raise JMCValueError(
-                "Unexpected empty arrow function",
-                self.raw_args["function"].token,
-                self.tokenizer,
-            )
-        if len(command) > 1:
-            raise JMCValueError(
-                f"'{
-                    self.call_string}' only allows 1 command (got {
-                    len(command)})",
-                self.raw_args["function"].token,
-                self.tokenizer,
-            )
-        if command[0].startswith("say"):
-            raise JMCValueError(
-                f"'{self.call_string}' doesn't allow 'say' command",
-                self.raw_args["function"].token,
-                self.tokenizer,
-                suggestion="This is due to minecraft's limitation",
-            )
+        _validate_single_command(
+            command, self.call_string, self.raw_args["function"].token, self.tokenizer
+        )
 
         if self.datapack.version < PackVersionFeature.TEXT_COMPONENT:
             outer_key, inner_key = "clickEvent", "value"
@@ -1440,27 +1400,9 @@ class TextPropsSuggestCommand(JMCFunction):
         command = self.datapack.parse_function_token(
             self.raw_args["function"].token, self.tokenizer, self.prefix
         )
-        if not command:
-            raise JMCValueError(
-                "Unexpected empty arrow function",
-                self.raw_args["function"].token,
-                self.tokenizer,
-            )
-        if len(command) > 1:
-            raise JMCValueError(
-                f"'{
-                    self.call_string}' only allows 1 command (got {
-                    len(command)})",
-                self.raw_args["function"].token,
-                self.tokenizer,
-            )
-        if command[0].startswith("say"):
-            raise JMCValueError(
-                f"'{self.call_string}' doesn't allow 'say' command",
-                self.raw_args["function"].token,
-                self.tokenizer,
-                suggestion="This is due to minecraft's limitation",
-            )
+        _validate_single_command(
+            command, self.call_string, self.raw_args["function"].token, self.tokenizer
+        )
 
         if self.datapack.version < PackVersionFeature.TEXT_COMPONENT:
             outer_key, inner_key = "clickEvent", "value"
@@ -2281,7 +2223,7 @@ class JMCRequire(JMCFunction):
             )
         return_1 = self.datapack.add_private_function(
             "require", "return 1", count="__return_1__", force_create_func=True
-        )[len("function ") :]
+        )[len("function "):]
         self.datapack.add_private_json(
             f"tags/function{'s' if self.datapack.version < PackVersionFeature.LEGACY_FOLDER_RENAME else ''}",
             f"require/{namespace}",

--- a/src/jmc/compile/command/nbt_operation.py
+++ b/src/jmc/compile/command/nbt_operation.py
@@ -115,10 +115,10 @@ def merge_path(
         elif string.endswith(")") and token.token_type == TokenType.KEYWORD:
             string += token.string
         else:
-            del tokens[start_index : start_index + index]
+            del tokens[start_index: start_index + index]
             return string
     assert index is not None
-    del tokens[start_index : start_index + index + 1]
+    del tokens[start_index: start_index + index + 1]
     return string
 
 
@@ -142,7 +142,7 @@ def extract_nbt(
     if nbt_type == NBTType.AUTO_STORAGE:
         if tokens[start_index].string == "::":
             path = merge_path(tokens, start_index + 1, tokenizer, datapack)
-            del tokens[start_index : start_index + 1]
+            del tokens[start_index: start_index + 1]
             return (
                 get_nbt_string(nbt_type),
                 datapack.namespace + ":" + datapack.namespace,
@@ -151,7 +151,7 @@ def extract_nbt(
         else:
             target = tokens[start_index].string
             path = merge_path(tokens, start_index + 2, tokenizer, datapack)
-            del tokens[start_index : start_index + 2]
+            del tokens[start_index: start_index + 2]
             return (
                 get_nbt_string(nbt_type),
                 datapack.namespace + ":" + target,
@@ -164,14 +164,14 @@ def extract_nbt(
             + tokens[start_index + 2].string
         )
         path = merge_path(tokens, start_index + 4, tokenizer, datapack)
-        del tokens[start_index : start_index + 4]
+        del tokens[start_index: start_index + 4]
         return get_nbt_string(nbt_type), target, " " + path if path else ""
     elif nbt_type == NBTType.BLOCK:
         target = " ".join(
             _token.string for _token in tokenizer.parse_list(tokens[start_index])
         )
         path = merge_path(tokens, start_index + 2, tokenizer, datapack)
-        del tokens[start_index : start_index + 2]
+        del tokens[start_index: start_index + 2]
         return get_nbt_string(nbt_type), target, " " + path if path else ""
     elif nbt_type == NBTType.ENTITY:
         if tokens[start_index + 1].token_type == TokenType.PAREN_SQUARE:
@@ -179,11 +179,11 @@ def extract_nbt(
                 tokens[start_index + 1], tokenizer
             )
             path = merge_path(tokens, start_index + 3, tokenizer, datapack)
-            del tokens[start_index : start_index + 3]
+            del tokens[start_index: start_index + 3]
         else:
             target = tokens[start_index].string
             path = merge_path(tokens, start_index + 2, tokenizer, datapack)
-            del tokens[start_index : start_index + 2]
+            del tokens[start_index: start_index + 2]
         return get_nbt_string(nbt_type), target, " " + path if path else ""
     raise NotImplementedError("Invalid nbt_type")
 

--- a/src/jmc/compile/command/utils.py
+++ b/src/jmc/compile/command/utils.py
@@ -18,6 +18,31 @@ from ..exception import JMCSyntaxException, JMCValueError
 from ..utils import clean_up_paren_token, is_number, is_float
 
 
+MINECRAFT_POSITION_REGEX = (
+    r"^[~\^]?-?\d*(\.\d+)?\s+[~\^]?-?\d*(\.\d+)?\s+[~\^]?-?\d*(\.\d+)?[~\^]?$"
+)
+
+_COLOR_NAMES: frozenset[str] = frozenset({
+    "dark_red",
+    "red",
+    "gold",
+    "yellow",
+    "dark_green",
+    "green",
+    "aqua",
+    "dark_aqua",
+    "blue",
+    "dark_blue",
+    "light_purple",
+    "dark_purple",
+    "white",
+    "gray",
+    "dark_gray",
+    "black",
+    "reset",
+})
+
+
 class PlayerType(Enum):
     VARIABLE = auto()
     INTEGER = auto()
@@ -64,12 +89,12 @@ def merge_obj_selector(
             tokens[start_index + 3].col,
             clean_up_paren_token(tokens[start_index + 3], tokenizer),
         )
-        return_value = tokenizer.merge_tokens(tokens[start_index : start_index + 4])
-        del tokens[start_index + 1 : start_index + 4]
+        return_value = tokenizer.merge_tokens(tokens[start_index: start_index + 4])
+        del tokens[start_index + 1: start_index + 4]
         return return_value
     elif len(tokens) >= start_index + 3:
-        return_value = tokenizer.merge_tokens(tokens[start_index : start_index + 3])
-        del tokens[start_index + 1 : start_index + 3]
+        return_value = tokenizer.merge_tokens(tokens[start_index: start_index + 3])
+        del tokens[start_index + 1: start_index + 3]
         return return_value
     raise ValueError(
         "Impossible tokens array length (merge_obj_selector used without is_obj_selector)"
@@ -361,7 +386,7 @@ def find_arg_type(tokens: list[Token], tokenizer: Tokenizer) -> ArgType:
                 )
             return ArgType.INTEGER
         if is_float(tokens[1].string):
-            if len(tokens) > 1:
+            if len(tokens) > 2:
                 raise JMCSyntaxException(
                     f"Unexpected {
                         tokens[2].token_type.value} after float/decimal in function argument",
@@ -516,11 +541,7 @@ def eval_expr(expr: str) -> str:
     if isinstance(number, float):
         if int(number) == number:
             return f"{int(number):d}"
-        if abs(number) >= 100:
-            return f"{number:.2f}"
-        elif abs(number) >= 10:
-            return f"{number:.3f}"
-        elif abs(number) >= 1:
+        if abs(number) >= 1:
             return f"{number:.3f}"
         string = f"{number:.12f}"
         whole, decimal = string.split(".")
@@ -702,25 +723,7 @@ class FormattedText:
             if prop.startswith("!"):
                 value = False
                 prop = prop[1:]
-            if prop in {
-                "dark_red",
-                "red",
-                "gold",
-                "yellow",
-                "dark_green",
-                "green",
-                "aqua",
-                "dark_aqua",
-                "blue",
-                "dark_blue",
-                "light_purple",
-                "dark_purple",
-                "white",
-                "gray",
-                "dark_gray",
-                "black",
-                "reset",
-            }:
+            if prop in _COLOR_NAMES:
                 if "color" in self.current_json:
                     raise JMCValueError(
                         f"color({prop}) used twice in formatted text",
@@ -860,7 +863,7 @@ class FormattedText:
 
             if prop.endswith(")"):
                 open_paren_index = prop.find("(")
-                arg = prop[open_paren_index + 1 : -1].strip()
+                arg = prop[open_paren_index + 1: -1].strip()
                 prop_ = prop[:open_paren_index]
                 if prop_ not in self.datapack.data.formatted_text_prop:
                     raise JMCValueError(
@@ -1005,27 +1008,9 @@ class FormattedText:
         """
         prop = self.PROPS.get(char, None)
         if prop is None:
-            JMCValueError(f"Unknown code format '{char}'", self.token, self.tokenizer)
+            raise JMCValueError(f"Unknown code format '{char}'", self.token, self.tokenizer)
 
-        if prop in {
-            "dark_red",
-            "red",
-            "gold",
-            "yellow",
-            "dark_green",
-            "green",
-            "aqua",
-            "dark_aqua",
-            "blue",
-            "dark_blue",
-            "light_purple",
-            "dark_purple",
-            "white",
-            "gray",
-            "dark_gray",
-            "black",
-            "reset",
-        }:
+        if prop in _COLOR_NAMES:
             self.current_json["color"] = prop
             self.current_color = prop
 
@@ -1176,7 +1161,7 @@ def hardcode_parse_calc(
         raise JMCSyntaxException(
             "Expected ( after Hardcode.calc", token, tokenizer, display_col_length=False
         )
-    for char in string[calc_pos + 13 :]:  # len('Hardcode.calc') = 13
+    for char in string[calc_pos + 13:]:  # len('Hardcode.calc') = 13
         index += 1
         if char == "(":
             count += 1
@@ -1231,7 +1216,7 @@ def hardcode_parse_calc(
                 display_col_length=False,
             )
 
-    return string[:calc_pos] + eval_expr(expression) + string[index + 13 :]
+    return string[:calc_pos] + eval_expr(expression) + string[index + 13:]
 
 
 def is_uuid(source: str) -> bool:
@@ -1256,8 +1241,3 @@ def guess_nbt_type(source: str) -> str:
         return "block"
 
     return "storage"
-
-
-MINECRAFT_POSITION_REGEX = (
-    r"^[~\^]?-?\d*(\.\d+)?\s+[~\^]?-?\d*(\.\d+)?\s+[~\^]?-?\d*(\.\d+)?[~\^]?$"
-)

--- a/src/jmc/compile/command/var_operation.py
+++ b/src/jmc/compile/command/var_operation.py
@@ -136,7 +136,7 @@ def variable_operation(
             token=tokenizer.merge_tokens(tokens[2:4]),
             tokenizer=tokenizer,
             suggestion=f"""Consider casting the vanilla macro using `<variable> <operator> (<type>) $(<vanilla_macro>)` syntax.
-Available types are: {", ".join("'"+casting_type+"'" for casting_type in CASTING_TYPES)}
+Available types are: {", ".join("'" + casting_type + "'" for casting_type in CASTING_TYPES)}
 Example: `$var = (const) $(my_int)`""",
         )
 
@@ -153,7 +153,7 @@ Example: `$var = (const) $(my_int)`""",
                 f"Unrecognized casting types for vanilla macro: {casting_type}",
                 token=vanilla_macro,
                 tokenizer=tokenizer,
-                suggestion=f"""Available types are: {", ".join("'"+casting_type+"'" for casting_type in CASTING_TYPES)}""",
+                suggestion=f"""Available types are: {", ".join("'" + casting_type + "'" for casting_type in CASTING_TYPES)}""",
             )
     elif (
         len(tokens) == 4
@@ -167,7 +167,7 @@ Example: `$var = (const) $(my_int)`""",
                 f"Unrecognized casting types for vanilla macro: {casting_type}",
                 token=vanilla_macro,
                 tokenizer=tokenizer,
-                suggestion=f"""Available types are: {", ".join("'"+casting_type+"'" for casting_type in CASTING_TYPES)}""",
+                suggestion=f"""Available types are: {", ".join("'" + casting_type + "'" for casting_type in CASTING_TYPES)}""",
             )
     else:
         vanilla_macro = None

--- a/src/jmc/compile/compiling.py
+++ b/src/jmc/compile/compiling.py
@@ -361,7 +361,7 @@ def build(
                 / "data"
                 / namespace
                 / function_folder
-                / (func_path[len(namespace) + 1 :] + ".mcfunction")
+                / (func_path[len(namespace) + 1:] + ".mcfunction")
             )
         else:
             path = namespace_folder / function_folder / (func_path + ".mcfunction")
@@ -381,7 +381,7 @@ def build(
                 output_folder
                 / "data"
                 / namespace
-                / (json_path[len(namespace) + 1 :] + ".json")
+                / (json_path[len(namespace) + 1:] + ".json")
             )
         else:
             path = namespace_folder / (json_path + ".json")

--- a/src/jmc/compile/lexer.py
+++ b/src/jmc/compile/lexer.py
@@ -638,7 +638,7 @@ class Lexer:
         namespace = json_name.split("/")[0]
         if namespace in Header().namespace_overrides:
             json_path = (
-                namespace + "/" + json_type + "/" + json_name[len(namespace) + 1 :]
+                namespace + "/" + json_type + "/" + json_name[len(namespace) + 1:]
             )
         else:
             json_path = json_type + "/" + json_name
@@ -686,7 +686,7 @@ class Lexer:
                     + "/"
                     + json_type
                     + "/"
-                    + extends_from[len(namespace) + 1 :]
+                    + extends_from[len(namespace) + 1:]
                 )
             else:
                 super_path = json_type + "/" + extends_from

--- a/src/jmc/compile/lexer_func_content.py
+++ b/src/jmc/compile/lexer_func_content.py
@@ -1,7 +1,6 @@
 """Module responsible for handling all Function Content parsing in Lexer"""
 
 from enum import Enum, auto
-from sys import prefix
 from typing import TYPE_CHECKING
 from json import dumps
 
@@ -56,7 +55,6 @@ FIRST_ARGUMENTS = {
     *LOAD_ONCE_COMMANDS,
     *LOAD_ONLY_COMMANDS,
     *JMC_COMMANDS,
-    *FLOW_CONTROL_COMMANDS,
     *EXECUTE_EXCLUDED_COMMANDS,
     *VANILLA_COMMANDS,
     "class",
@@ -185,9 +183,6 @@ class FuncContent:
             raise JMCSyntaxException(
                 "'class' keyword found in function", self.command[0], self.tokenizer
             )
-        # if is_decorator(self.command[0].string):
-        #     raise JMCSyntaxException(
-        #         "Decorated function declaration found in function", self.command[0], self.tokenizer)
         if self.command[0].string == "import":
             raise JMCSyntaxException(
                 "Importing found in function", self.command[0], self.tokenizer
@@ -277,7 +272,7 @@ class FuncContent:
             if self.expanded_commands is not None:
                 for expanded_command in self.expanded_commands:
                     if expanded_command.startswith("execute"):
-                        expanded_command = expanded_command[len("execute") + 1 :]
+                        expanded_command = expanded_command[len("execute") + 1:]
                         self.command_strings.append(
                             " ".join(self.__commands[:-1])
                             + " "
@@ -422,15 +417,7 @@ class FuncContent:
         if self.__optimize(token):
             return
 
-        if token.token_type == TokenType.PAREN_ROUND:
-            if is_connected(token, self.command[key_pos - 1]):
-                self.__commands[-1] += clean_up_paren_token(token, self.tokenizer)
-            else:
-                append_commands(
-                    self.__commands,
-                    clean_up_paren_token(token, self.tokenizer),
-                )
-        elif token.token_type in {TokenType.PAREN_CURLY, TokenType.PAREN_SQUARE}:
+        if token.token_type in {TokenType.PAREN_ROUND, TokenType.PAREN_CURLY, TokenType.PAREN_SQUARE}:
             if is_connected(token, self.command[key_pos - 1]):
                 self.__commands[-1] += clean_up_paren_token(token, self.tokenizer)
             else:
@@ -519,9 +506,7 @@ class FuncContent:
         if token.string == "with":
             self.__handle_with_anon(key_pos, token)
             if len(self.command) <= key_pos + 1:
-                raise JMCSyntaxException(
-                    f"Expected a token after 'with'", token, self.tokenizer
-                )
+                raise JMCSyntaxException("Expected a token after 'with'", token, self.tokenizer)
             if self.__handle_with(key_pos, token):
                 return SKIP_TO_NEXT_LINE
 
@@ -595,10 +580,9 @@ class FuncContent:
         ):
             if self.is_execute:
                 raise JMCSyntaxException(
-                    f"This feature({
-                        token.string}) can only be used in load function",
+                    f"This feature({token.string}) can only be used in load function",
                     token,
-                    self.tokenizer,
+                    self.tokenizer
                 )
 
         if (
@@ -608,23 +592,8 @@ class FuncContent:
             return self.__handle_function_call(key_pos, token)
 
         if not self._bypass_checks:
-            if (
-                token.string not in VANILLA_COMMANDS
-                and token.string not in Header().commands
-            ):
-                if not self.command_strings:
-                    raise JMCSyntaxException(
-                        f"Unrecognized command ({
-                            token.string})",
-                        token,
-                        self.tokenizer,
-                    )
-                raise JMCSyntaxException(
-                    f"Unrecognized command ({
-                        token.string})",
-                    token,
-                    self.tokenizer,
-                )
+            if (token.string not in VANILLA_COMMANDS and token.string not in Header().commands):
+                raise JMCSyntaxException(f"Unrecognized command ({token.string})", token, self.tokenizer)
 
         if self.__optimize(token):
             return CONTINUE_LINE
@@ -902,7 +871,7 @@ class FuncContent:
             )
             return SKIP_TO_NEXT_LINE
 
-        __with_nbt_type = get_nbt_type(self.command[key_pos + 1 :])
+        __with_nbt_type = get_nbt_type(self.command[key_pos + 1:])
         if __with_nbt_type is None:
             token_ = self.command[key_pos + 1]
             if token_.token_type != TokenType.PAREN_CURLY:
@@ -1168,7 +1137,7 @@ class FuncContent:
                     raise var_error
                 raise normal_error
             if not self.__commands:
-                return SKIP_TO_NEXT_LINE  # TODO: Will this break anything?
+                return SKIP_TO_NEXT_LINE  # nothing generated, no $ prefix to apply
             self.__commands[0] = "$" + self.__commands[0]
         return SKIP_TO_NEXT_LINE
 

--- a/src/jmc/compile/tokenizer.py
+++ b/src/jmc/compile/tokenizer.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
 logger = Logger(__name__)
 
-NEW_LINE = "\n"
-
 TERMINATE_LINE = {
     "function",
     "class",
@@ -67,9 +65,6 @@ class Token:
     quote: str = ""
     _embeded_data: Any = field(default=None, repr=False)
 
-    # def __new__(cls: type["Token"], token_type: TokenType, line: int, col: int, string: str) -> "Token":
-    #     return super().__new__(cls)
-
     def __post_init__(self) -> None:
         """
         Edit string and _length according to macros(`#define something`) defined
@@ -87,14 +82,11 @@ class Token:
 
         :return: Length of the string
         """
-        # if not self._macro_length:
         return (
             len(repr(self.string))
             if self.token_type == TokenType.STRING
             else len(self.string)
         )
-        # else:
-        #     return self._macro_length
 
     def add_quotation(self) -> str:
         """Get self.string including quotation mark (Raise error when the token_type is not TokenType.STRING)"""
@@ -334,10 +326,6 @@ class Tokenizer:
             args: list[Token] = []
             args_, kwargs = deepcopy(self).parse_func_args(new_token)
             for arg_ in args_:
-                # if arg_[0].token_type != TokenType.KEYWORD:
-                #     raise JMCSyntaxException(
-                # f"Macro factory arguments can only have a keyword token (got
-                # {arg_[0].token_type})", arg_[0], self)
                 if len(arg_) > 1:
                     arg_ = [self.merge_tokens(arg_)]
 
@@ -487,7 +475,7 @@ class Tokenizer:
         self.col = 0
 
     def __parse_multiline_string(self):
-        lines = self.token_str.split(NEW_LINE)
+        lines = self.token_str.split(Re.NEW_LINE)
         if len(lines) <= 2:
             if len(lines) == 1:
                 raise JMCSyntaxException(
@@ -1069,8 +1057,46 @@ class Tokenizer:
 
         return tokens
 
-    # def parse_nbt(self, token: Token) -> dict[str, str]:
-    #     return {}
+    def _parse_kv_token(self, token: Token, separator: str, context: str) -> dict[str, Token]:
+        statements = self.parse(
+            token.string[1:-1],
+            line=token.line,
+            col=token.col + 1,
+            expect_semicolon=False,
+        )
+        if not statements:
+            return {}
+        keywords: list[Token] = statements[0]
+
+        result: dict[str, Token] = {}
+        comma_separated_tokens = self.find_token(keywords, ",")
+        if not comma_separated_tokens[-1]:
+            raise JMCSyntaxException(f"Unexpected comma at the end of {context}", keywords[-1], self)
+        comma_token_index = 0
+        for comma_separated_token in comma_separated_tokens:
+            if not comma_separated_token:
+                raise JMCSyntaxException(f"Unexpected comma in {context}", keywords[comma_token_index], self)
+            comma_token_index += len(comma_separated_token) + 1
+
+            if (len(comma_separated_token) == 1 or comma_separated_token[1].string != separator):
+                raise JMCSyntaxException(
+                    f"Expected 'key{separator}value' in {context}",
+                    comma_separated_token[0],
+                    self,
+                )
+
+            if len(comma_separated_token) == 2:
+                raise JMCSyntaxException(
+                    f"Expected value after '{separator}' in {context}",
+                    comma_separated_token[1],
+                    self,
+                )
+            key = comma_separated_token[0].string
+            value = self.__parse_func_arg(comma_separated_token[2:], False, is_nbt=True)
+            if key in result:
+                raise JMCSyntaxException(f"Duplicated key({key})", comma_separated_token[0], self)
+            result[key] = self.merge_tokens(value)
+        return result
 
     def parse_component(self, token: Token) -> dict[str, Token]:
         """
@@ -1081,60 +1107,9 @@ class Tokenizer:
         """
         if token.token_type != TokenType.PAREN_SQUARE:
             raise JMCSyntaxException(
-                "Expected JavaScript Object", token, self, suggestion="Expected {"
+                "Expected JavaScript Object", token, self, suggestion="Expected ["
             )
-        _keywords = self.parse(
-            token.string[1:-1],
-            line=token.line,
-            col=token.col + 1,
-            expect_semicolon=False,
-        )
-        if not _keywords:
-            return {}
-        keywords = _keywords[0]
-        component: dict[str, Token] = {}
-        comma_separated_tokens = self.find_token(keywords, ",")
-        if not comma_separated_tokens[-1]:
-            raise JMCSyntaxException(
-                "Unexpected comma at the end of component", keywords[-1], self
-            )
-        comma_token_index = 0
-        for comma_separated_token in comma_separated_tokens:
-            # List of tokens between commas
-            if not comma_separated_token:
-                raise JMCSyntaxException(
-                    "Unexpected comma in component",
-                    keywords[comma_token_index],
-                    self,
-                )
-            comma_token_index += len(comma_separated_token) + 1
-
-            if (
-                len(comma_separated_token) == 1
-                or comma_separated_token[1].string != "="
-            ):
-                raise JMCSyntaxException(
-                    "Expected 'key=value' in component",
-                    comma_separated_token[0],
-                    self,
-                )
-
-            if len(comma_separated_token) == 2:
-                raise JMCSyntaxException(
-                    "Expected value after '=' in component",
-                    comma_separated_token[1],
-                    self,
-                )
-            key = comma_separated_token[0].string
-            value = self.__parse_func_arg(comma_separated_token[2:], False, is_nbt=True)
-            if key in component:
-                raise JMCSyntaxException(
-                    f"Duplicated key({key})", comma_separated_token[0], self
-                )
-            component[key] = self.merge_tokens(value)
-            continue
-
-        return component
+        return self._parse_kv_token(token, "=", "component")
 
     def parse_js_obj(self, token: Token) -> dict[str, Token]:
         """
@@ -1147,58 +1122,7 @@ class Tokenizer:
             raise JMCSyntaxException(
                 "Expected JavaScript Object", token, self, suggestion="Expected {"
             )
-        _keywords = self.parse(
-            token.string[1:-1],
-            line=token.line,
-            col=token.col + 1,
-            expect_semicolon=False,
-        )
-        if not _keywords:
-            return {}
-        keywords = _keywords[0]
-        js_obj: dict[str, Token] = {}
-        comma_separated_tokens = self.find_token(keywords, ",")
-        if not comma_separated_tokens[-1]:
-            raise JMCSyntaxException(
-                "Unexpected comma at the end of JSObject/NBT", keywords[-1], self
-            )
-        comma_token_index = 0
-        for comma_separated_token in comma_separated_tokens:
-            # List of tokens between commas
-            if not comma_separated_token:
-                raise JMCSyntaxException(
-                    "Unexpected comma in JSObject/NBT",
-                    keywords[comma_token_index],
-                    self,
-                )
-            comma_token_index += len(comma_separated_token) + 1
-
-            if (
-                len(comma_separated_token) == 1
-                or comma_separated_token[1].string != ":"
-            ):
-                raise JMCSyntaxException(
-                    "Expected 'key:value' in JSObject/NBT",
-                    comma_separated_token[0],
-                    self,
-                )
-
-            if len(comma_separated_token) == 2:
-                raise JMCSyntaxException(
-                    "Expected value after ':' in JSObject/NBT",
-                    comma_separated_token[1],
-                    self,
-                )
-            key = comma_separated_token[0].string
-            value = self.__parse_func_arg(comma_separated_token[2:], False, is_nbt=True)
-            if key in js_obj:
-                raise JMCSyntaxException(
-                    f"Duplicated key({key})", comma_separated_token[0], self
-                )
-            js_obj[key] = self.merge_tokens(value)
-            continue
-
-        return js_obj
+        return self._parse_kv_token(token, ":", "JSObject/NBT")
 
     def merge_vanilla_macro(self, tokens: list[Token], key_pos: int):
         if (
@@ -1211,8 +1135,8 @@ class Tokenizer:
                 and tokens[key_pos + 2].token_type == TokenType.KEYWORD
                 and is_connected(tokens[key_pos + 2], tokens[key_pos + 1])
             ):
-                tokens[key_pos] = self.merge_tokens(tokens[key_pos : key_pos + 3])
-                del tokens[key_pos + 1 : key_pos + 3]
+                tokens[key_pos] = self.merge_tokens(tokens[key_pos: key_pos + 3])
+                del tokens[key_pos + 1: key_pos + 3]
             else:
-                tokens[key_pos] = self.merge_tokens(tokens[key_pos : key_pos + 2])
+                tokens[key_pos] = self.merge_tokens(tokens[key_pos: key_pos + 2])
                 del tokens[key_pos + 1]

--- a/src/jmc/compile/utils.py
+++ b/src/jmc/compile/utils.py
@@ -218,7 +218,7 @@ def convention_jmc_to_mc(
     else:
         string = custom_string
     if substr is not None:
-        string = string[substr[0] : substr[1]]
+        string = string[substr[0]: substr[1]]
     if string.startswith("."):
         raise JMCSyntaxException("Name started with '.'", token, tokenizer)
     if string.endswith("."):

--- a/src/tests/integration/test_jmc_function.py
+++ b/src/tests/integration/test_jmc_function.py
@@ -1242,7 +1242,7 @@ JMC.python(`
         self.assertIn("scoreboard players set $result __variable__ 5", load)
 
     def test_jmc_true_output_longer_than_source(self):
-        # Ensures generated content can have more lines than the source file. 
+        # Ensures generated content can have more lines than the source file.
         # parse_function_token must use generated content as file_string.
         pack = (
             JMCTestPack()


### PR DESCRIPTION
I discovered the `code_test_linux.sh` script and created this PR to correct whitespace and formatting issues. I ran across a few sections of duplicated source (if blocks with the same results on both branches, etc) and decided to fix them as well.

In doing this I encountered three bugs and corrected them:
- `utils.py:1011`: missing `raise` before JMCValueError (no error thrown before)
- `utils.py:389`:  changed len(tokens) > 1 to > 2 in signed-float branch. Before this would cause index out of bounds crash for things like `Particle.circle("dust 1 0 0 1", -1.5, 10, 0);` instead of handling the negative then throwing the correct error.
- `tokenizer.py:1110`: Changed "Expected {" to "Expected [" in error message