### PR TITLE
Fix vanilla macro in vanilla matches statement

### DIFF
--- a/src/jmc/compile/command/condition.py
+++ b/src/jmc/compile/command/condition.py
@@ -546,6 +546,15 @@ def _resolve_number_macro(raw: str, header: Header) -> str:
     return sign + header.number_macros.get(digits, digits)
 
 
+def _is_vanilla_macro(value: str) -> bool:
+    """
+    Whether a matches-value string is a vanilla `$(macro)` substitution
+    (resolved by Minecraft at runtime, not by JMC at compile time)
+    """
+    value = value[1:] if value.startswith("-") else value
+    return value.startswith("$(") and value.endswith(")")
+
+
 def extract_matches(
     tokenizer: Tokenizer, token: Token, first_token: Token | None
 ) -> str:
@@ -558,14 +567,17 @@ def extract_matches(
     :param first_token: The JMC variable/selector token to the left of 'matches' in
         JMC's own `if (var matches ...)` syntax, or None when parsing a bare vanilla
         command.
-    :return: The resolved matches value, e.g. '0..5', '5..', '..5', or (vanilla-only) '5'
+    :return: The resolved matches value, e.g. '0..5', '5..', '..5', or vanilla-only '5', $(foo), $(foo)..
     """
     match_tokens_ = tokenizer.split_keyword_token(token, "..")
     match_tokens = tokenizer.find_token(match_tokens_, "..")
     header = Header()
 
     if len(match_tokens) == 1 and first_token is None:
-        value = _resolve_number_macro(match_tokens[0][0].string, header)
+        raw = match_tokens[0][0].string
+        if _is_vanilla_macro(raw):
+            return raw
+        value = _resolve_number_macro(raw, header)
         if not is_number(value):
             raise JMCSyntaxException(
                 f"Expected integer after 'matches' (got '{value}')",
@@ -607,26 +619,35 @@ def extract_matches(
             tokenizer,
             suggestion="There must be at least 1 integer. '..' doesn't mean anything.",
         )
+    first_raw = match_tokens[0][0].string if has_first else ""
+    second_raw = match_tokens[1][0].string if has_second else ""
+    first_is_not_macro = first_token is not None or not has_first or not _is_vanilla_macro(first_raw)
+    second_is_not_macro = first_token is not None or not has_second or not _is_vanilla_macro(second_raw)
+
     first = (
-        _resolve_number_macro(match_tokens[0][0].string, header) if has_first else ""
+        _resolve_number_macro(first_raw, header)
+        if has_first and first_is_not_macro
+        else first_raw
     )
     second = (
-        _resolve_number_macro(match_tokens[1][0].string, header) if has_second else ""
+        _resolve_number_macro(second_raw, header)
+        if has_second and second_is_not_macro
+        else second_raw
     )
-    if first and not is_number(first):
+    if first and first_is_not_macro and not is_number(first):
         raise JMCSyntaxException(
             f"Expected integer after 'matches' (got '{first}')",
             match_tokens[0][0],
             tokenizer,
         )
-    if second and not is_number(second):
+    if second and second_is_not_macro and not is_number(second):
         raise JMCSyntaxException(
             f"Expected integer after '..' (got '{second}')",
             match_tokens[1][0],
             tokenizer,
         )
-    first_int = int(first) if has_first else None
-    second_int = int(second) if has_second else None
+    first_int = int(first) if has_first and first_is_not_macro else None
+    second_int = int(second) if has_second and second_is_not_macro else None
 
     if first_int is not None and second_int is not None:
         if first_int == second_int:
@@ -647,4 +668,6 @@ def extract_matches(
                 tokenizer,
                 suggestion=f"Did you mean {match_tokens[1][0].string}..{match_tokens[0][0].string} ?",
             )
-    return f"{'' if first_int is None else first_int}..{'' if second_int is None else second_int}"
+    first_display = "" if not has_first else (first_int if first_is_not_macro else first)
+    second_display = "" if not has_second else (second_int if second_is_not_macro else second)
+    return f"{first_display}..{second_display}"

--- a/src/jmc/compile/lexer_func_content.py
+++ b/src/jmc/compile/lexer_func_content.py
@@ -808,6 +808,11 @@ class FuncContent:
                 return None
             return self.command[key_pos]
 
+        # Collapse vanilla macros (e.g. `$(opp_team)`) after 'matches' into a
+        # single token before inspecting them, same as condition_to_ast does.
+        for pos in range(key_pos + 1, len(self.command)):
+            self.tokenizer.merge_vanilla_macro(self.command, pos)
+
         token_1 = _get_token(key_pos + 1)
         if token_1 is None:
             raise MinecraftSyntaxWarning(

--- a/src/tests/integration/test_flow_controls.py
+++ b/src/tests/integration/test_flow_controls.py
@@ -219,6 +219,36 @@ execute if score @s test matches -5 run say Hello World
             """),
         )
 
+    def test_vanilla_matches_macro_passthrough(self):
+        pack = JMCTestPack().set_jmc_file("""
+$execute unless score @s foo matches $(value) run say "hi";
+$execute unless score @s foo matches -$(value) run say "hi";
+$execute unless score @s foo matches $(value).. run say "hi";
+$execute unless score @s foo matches ..$(value) run say "hi";
+$execute unless score @s foo matches $(value)..5 run say "hi";
+$execute unless score @s foo matches 0..$(value) run say "hi";
+        """).build()
+
+        self.assertDictEqual(
+            pack.built,
+            string_to_tree_dict("""
+> VIRTUAL/data/minecraft/tags/functions/load.json
+{
+    "values": [
+        "TEST:__load__"
+    ]
+}
+> VIRTUAL/data/TEST/functions/__load__.mcfunction
+scoreboard objectives add __variable__ dummy
+$execute unless score @s foo matches $(value) run say hi
+$execute unless score @s foo matches -$(value) run say hi
+$execute unless score @s foo matches $(value).. run say hi
+$execute unless score @s foo matches ..$(value) run say hi
+$execute unless score @s foo matches $(value)..5 run say hi
+$execute unless score @s foo matches 0..$(value) run say hi
+            """),
+        )
+
     def test_logic_gate(self):
         pack = JMCTestPack().set_jmc_file("""
 if (!entity @s[type=skeleton] || (entity @s[type=zombie] && $deathCount>5)) {

--- a/src/tests/integration/test_header.py
+++ b/src/tests/integration/test_header.py
@@ -326,6 +326,14 @@ if (test:@s matches A..) {
 #define A 1
         """).build()
 
+    def test_flow_control_vanilla_macro_rejected(self):
+        with self.assertRaises(JMCSyntaxException):
+            JMCTestPack().set_jmc_file("""
+$if (test:@s matches $(min)..10) {
+    say "hi";
+}
+        """).build()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The recent addition of [header support in vanilla matches](https://github.com/WingedSeal/jmc/commit/bbe3d022fc7f41b6af0bfaf559b3a8eb9cb72180) seems to have also broken the vanilla macro syntax within matches clauses:
```
$execute unless score @s foo matches $(bar) run say "hi";
```
This PR patches that up while still throwing errors when using a macro in `matches <int>` in conditionals. I added a few more unit tests to cover this in the future.